### PR TITLE
return after bindNull

### DIFF
--- a/coffee/api.coffee
+++ b/coffee/api.coffee
@@ -185,8 +185,8 @@ class Statement
 			when "string" then @bindString val, pos
 			when "number","boolean" then @bindNumber val+0, pos
 			when "object"
-				if val is null then return @bindNull pos
-				if val.length? then @bindBlob val, pos
+				if val is null then @bindNull pos
+				else if val.length? then @bindBlob val, pos
 				else throw "Wrong API use : tried to bind a value of an unknown type (#{val})."
 	### Bind names and values of an object to the named parameters of the statement
 	@param [Object]


### PR DESCRIPTION
bindValue does not terminate after a `null` bind. `val.length` on line 189 will throw an error.
