### PR TITLE
[RFC] dist/sql-asm-memory-growth-debug.js build target support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ EXPORTED_METHODS_JSON_FILES = src/exported_functions.json src/exported_runtime_m
 all: optimized debug worker
 
 .PHONY: debug
-debug: dist/sql-asm-debug.js dist/sql-wasm-debug.js
+debug: dist/sql-asm-debug.js dist/sql-wasm-debug.js dist/sql-asm-memory-growth-debug.js
 
 dist/sql-asm-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(OUTPUT_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
 	$(EMCC) $(EMFLAGS) $(EMFLAGS_DEBUG) $(EMFLAGS_ASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
@@ -82,6 +82,12 @@ dist/sql-asm-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(OUTPUT_API_FIL
 
 dist/sql-wasm-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(OUTPUT_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
 	$(EMCC) $(EMFLAGS) $(EMFLAGS_DEBUG) $(EMFLAGS_WASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
+	mv $@ out/tmp-raw.js
+	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
+	rm out/tmp-raw.js
+
+dist/sql-asm-memory-growth-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(OUTPUT_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
+	$(EMCC) $(EMFLAGS) $(EMFLAGS_DEBUG) $(EMFLAGS_ASM_MEMORY_GROWTH) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
 	mv $@ out/tmp-raw.js
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
 	rm out/tmp-raw.js

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ For each [relase](https://github.com/kripken/sql.js/releases/), you will find a 
  - `sql-asm.js` : The older asm.js version of Sql.js. Slower and larger. Provided for compatibility reasons.
  - `sql-asm-memory-growth.js` : Asm.js doesn't allow for memory to grow by default, because it is slower and de-optimizes. If you are using sql-asm.js and you see this error (`Cannot enlarge memory arrays`), use this file.
  - `sql-asm-debug.js` : The _Debug_ asm.js version of Sql.js. Use this for local development.
+ - `dist/sql-asm-memory-growth-debug.js` : The _Debug_ asm.js version of Sql.js, with solution for the memory issue (`Cannot enlarge memory arrays`).
  - `worker.*` - Web Worker versions of the above libraries. More limited API. See [examples/GUI/gui.js](examples/GUI/gui.js) for a good example of this.
 
 ## Compiling

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
 	"scripts": {
 		"build": "make",
 		"rebuild": "make clean && make",
-		"test": "npm run test-asm && npm run test-asm-debug && npm run test-wasm && npm run test-wasm-debug && npm run test-asm-memory-growth",
+		"test": "npm run test-asm && npm run test-asm-debug && npm run test-wasm && npm run test-wasm-debug && npm run test-asm-memory-growth && npm run test-asm-memory-growth-debug",
 		"test-asm": "node test/all.js asm",
 		"test-asm-debug": "node test/all.js asm-debug",
 		"test-asm-memory-growth": "node test/all.js asm-memory-growth",
+		"test-asm-memory-growth-debug": "node test/all.js asm-memory-growth-debug",
 		"test-wasm": "node test/all.js wasm",
 		"test-wasm-debug": "node test/all.js wasm-debug"
 	},


### PR DESCRIPTION
(updated)

- add this debug target to `Makefile`
- quick documentation in `README.md`
- _add sql-asm-memory-growth-debug to npm test_

This PR is assuming that we do want to continue actively supporting the asm.js build targets and do not want to enable the memory growth in the existing `dist/sql-asm-debug.js` build target.

originally proposed as part of PR #319