### PR TITLE
Prevent bind error with undefined/null parameters

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -251,10 +251,15 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
             throw "Statement closed";
         }
         this["reset"]();
-        if (Array.isArray(values)) {
-            return this.bindFromArray(values);
+        var bindResult = true;
+        if (values) {
+            if (Array.isArray(values)) {
+                bindResult = this.bindFromArray(values);
+            } else {
+                bindResult = this.bindFromObject(values);
+            }
         }
-        return this.bindFromObject(values);
+        return bindResult;
     };
 
     /** Execute the statement, fetching the the next line of result,

--- a/src/api.js
+++ b/src/api.js
@@ -254,7 +254,7 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
         }
         this["reset"]();
         if (Array.isArray(values)) return this.bindFromArray(values);
-        if (typeof values === "object") return this.bindFromObject(values);
+        if (values != null && typeof values === "object") return this.bindFromObject(values);
         return true;
     };
 

--- a/src/api.js
+++ b/src/api.js
@@ -253,15 +253,9 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
             throw "Statement closed";
         }
         this["reset"]();
-        var bindResult = true;
-        if (values) {
-            if (Array.isArray(values)) {
-                bindResult = this.bindFromArray(values);
-            } else {
-                bindResult = this.bindFromObject(values);
-            }
-        }
-        return bindResult;
+        if (Array.isArray(values)) return this.bindFromArray(values);
+        if (typeof values === "object") return this.bindFromArray(values);
+        return true;
     };
 
     /** Execute the statement, fetching the the next line of result,

--- a/src/api.js
+++ b/src/api.js
@@ -254,7 +254,7 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
         }
         this["reset"]();
         if (Array.isArray(values)) return this.bindFromArray(values);
-        if (typeof values === "object") return this.bindFromArray(values);
+        if (typeof values === "object") return this.bindFromObject(values);
         return true;
     };
 

--- a/src/api.js
+++ b/src/api.js
@@ -208,9 +208,11 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
     }
 
     /** @typedef {string|number|null|Uint8Array} Database.SqlValue */
-    /** @typedef {Database.SqlValue[]|Object<string, Database.SqlValue>} Statement.BindParams */
+    /** @typedef {Database.SqlValue[]|Object<string, Database.SqlValue>|null} Statement.BindParams
+     */
 
-    /** Bind values to the parameters, after having reseted the statement
+    /** Bind values to the parameters, after having reseted the statement.
+    * If values is null, do nothing and return true.
     *
     * SQL statements can have parameters, named *'?', '?NNN', ':VVV', '@VVV', '$VVV'*,
     * where NNN is a number and VVV a string.

--- a/test/test_statement.js
+++ b/test/test_statement.js
@@ -65,6 +65,14 @@ exports.test = function(sql, assert){
     result = stmt.get({':start':1, ':end':1});
     assert.deepEqual(result, ['a',1], "Binding named parameters");
 
+    // Prepare statement, pass null to bind() and check that it works
+    stmt = db.prepare("SELECT 'bind-with-null'");
+    result = stmt.bind(null);
+    assert.equal(result, true);
+    stmt.step();
+    result = stmt.get();
+    assert.equal(result,"bind-with-null")
+
     // Close the database and all associated statements
     db.close();
 };


### PR DESCRIPTION
In some client library (eg: typeorm) Statement.bind function could be called with undefined or null parameters. 
https://github.com/typeorm/typeorm/blob/ce07824df4305cb93222959db0804a7d62218c09/src/driver/sqljs/SqljsQueryRunner.ts#L55