### PR TITLE
- make worker.sql-wasm.js isomorphic (will load in web-worker, nodejs, and browser without errors).

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -1,91 +1,102 @@
 /* global initSqlJs */
 /* eslint-env worker */
+/* eslint func-names: ["off"] */
 /* eslint no-restricted-globals: ["error"] */
-var db;
 
-function onModuleReady(SQL) {
+
+// encapsulate web-worker code to run in any env
+(function () {
     "use strict";
 
-    function createDb(data) {
-        if (db != null) db.close();
-        db = new SQL.Database(data);
-        return db;
+    // isomorphism - do not run worker.js code if not in web-worker env
+    if (!(
+        typeof self === "object"
+        && typeof importScripts === "function"
+        && typeof self
+        && self.importScripts === importScripts
+    )) {
+        return;
     }
 
-    var buff; var data; var result;
-    data = this["data"];
-    switch (data && data["action"]) {
-        case "open":
-            buff = data["buffer"];
-            createDb(buff && new Uint8Array(buff));
-            return postMessage({
-                id: data["id"],
-                ready: true
-            });
-        case "exec":
-            if (db === null) {
-                createDb();
-            }
-            if (!data["sql"]) {
-                throw "exec: Missing query string";
-            }
-            return postMessage({
-                id: data["id"],
-                results: db.exec(data["sql"], data["params"])
-            });
-        case "each":
-            if (db === null) {
-                createDb();
-            }
-            var callback = function callback(row) {
-                return postMessage({
-                    id: data["id"],
-                    row: row,
-                    finished: false
-                });
-            };
-            var done = function done() {
-                return postMessage({
-                    id: data["id"],
-                    finished: true
-                });
-            };
-            return db.each(data["sql"], data["params"], callback, done);
-        case "export":
-            buff = db["export"]();
-            result = {
-                id: data["id"],
-                buffer: buff
-            };
-            try {
-                return postMessage(result, [result]);
-            } catch (error) {
-                return postMessage(result);
-            }
-        case "close":
-            return db && db.close();
-        default:
-            throw new Error("Invalid action : " + (data && data["action"]));
-    }
-}
-
-function onError(err) {
-    "use strict";
-
-    return postMessage({
-        id: this["data"]["id"],
-        error: err["message"]
-    });
-}
-
-if (typeof importScripts === "function") {
-    db = null;
+    // Declare toplevel variables
+    var db = null;
     var sqlModuleReady = initSqlJs();
-    self.onmessage = function onmessage(event) {
-        "use strict";
 
+    function onModuleReady(SQL) {
+        function createDb(data) {
+            if (db != null) db.close();
+            db = new SQL.Database(data);
+            return db;
+        }
+
+        var buff; var data; var result;
+        data = this["data"];
+        switch (data && data["action"]) {
+            case "open":
+                buff = data["buffer"];
+                createDb(buff && new Uint8Array(buff));
+                return postMessage({
+                    id: data["id"],
+                    ready: true
+                });
+            case "exec":
+                if (db === null) {
+                    createDb();
+                }
+                if (!data["sql"]) {
+                    throw "exec: Missing query string";
+                }
+                return postMessage({
+                    id: data["id"],
+                    results: db.exec(data["sql"], data["params"])
+                });
+            case "each":
+                if (db === null) {
+                    createDb();
+                }
+                var callback = function callback(row) {
+                    return postMessage({
+                        id: data["id"],
+                        row: row,
+                        finished: false
+                    });
+                };
+                var done = function done() {
+                    return postMessage({
+                        id: data["id"],
+                        finished: true
+                    });
+                };
+                return db.each(data["sql"], data["params"], callback, done);
+            case "export":
+                buff = db["export"]();
+                result = {
+                    id: data["id"],
+                    buffer: buff
+                };
+                try {
+                    return postMessage(result, [result]);
+                } catch (error) {
+                    return postMessage(result);
+                }
+            case "close":
+                return db && db.close();
+            default:
+                throw new Error("Invalid action : " + (data && data["action"]));
+        }
+    }
+
+    function onError(err) {
+        return postMessage({
+            id: this["data"]["id"],
+            error: err["message"]
+        });
+    }
+
+    db = null;
+    self.onmessage = function onmessage(event) {
         return sqlModuleReady
             .then(onModuleReady.bind(event))
             .catch(onError.bind(event));
     };
-}
+}());

--- a/src/worker.js
+++ b/src/worker.js
@@ -93,7 +93,7 @@
         });
     }
 
-    db = null;
+    // init web-worker onmessage event-handling
     self.onmessage = function onmessage(event) {
         return sqlModuleReady
             .then(onModuleReady.bind(event))

--- a/test/test_worker.js
+++ b/test/test_worker.js
@@ -42,6 +42,8 @@ exports.test = async function test(SQL, assert) {
   };
   // If we use puppeteer, we need to pass in this new cwd as the root of the file being loaded:
   const filename = "../dist/worker." + file + ".js";
+  // test worker.sql-wasm.js isomorphism - can be safely loaded in nodejs
+  require(filename);
   var worker = await Worker.fromFile(path.join(__dirname, filename));
   var data = await worker.postMessage({ id: 1, action: 'open' });
   assert.strictEqual(data.id, 1, "Return the given id in the correct format");


### PR DESCRIPTION
this pull-request simplifies devops/product-development
by removing the need to choose between worker and non-worker-variant js-file.

since `worker.sql-wasm.js` is now isomorphic, it can be used in non-worker context as well, e.g.:

```html
<html>
<body>
<!-- use worker.sql-wasm.js in non-web-worker env -->
<script src="dist/worker.sql-wasm.js"></script>
<script>
(async function () {
    "use strict"
    var sql = await initSqlJs();
    var db = new sql.Database();
    ...
}());
</script>
</body>
</html>
```

the change to src/worker.js is less drastic than it seems.  i simply indented/wrapped worker code in isomorphic wrapper:

```javascript
// encapsulate web-worker code to run in any env
(function () {
    "use strict";

    // isomorphism - do not run worker.js code if not in web-worker env
    if (!(
        typeof self === "object"
        && typeof importScripts === "function"
        && typeof self
        && self.importScripts === importScripts
    )) {
        return;
    }

    ...

}());
```


i've successfully deployed and used this one-size-fits-all `worker.sql-wasm.js` in both worker and non-worker applications for the past 3 months.