### PR TITLE
eslint /test/ directory

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,24 @@ module.exports = {
         "/out/",
         "/src/shell-post.js",
         "/src/shell-pre.js",
-        "/test/",
+        "/test/all.js",
+        "/test/disabled_test_memory_leak_on_error.js",
+        "/test/load_sql_lib.js",
+        "/test/test_blob.js",
+        "/test/test_database.js",
+        "/test/test_errors.js",
+        "/test/test_extension_functions.js",
+        "/test/test_functions.js",
+        "/test/test_functions_recreate.js",
+        "/test/test_issue128.js",
+        "/test/test_issue325.js",
+        "/test/test_issue55.js",
+        "/test/test_issue73.js",
+        "/test/test_issue76.js",
+        "/test/test_modularization.js",
+        "/test/test_node_file.js",
+        "/test/test_statement.js",
+        "/test/test_transactions.js",
         "!/.eslintrc.js"
     ],
     parserOptions: {
@@ -36,6 +53,10 @@ module.exports = {
         // reason - string-notation needed to prevent closure-minifier
         // from mangling property-name
         "dot-notation": "off",
+        // reason - test-cases use nameless, anonymous-functions for callbacks
+        "func-names": "off",
+        // reason - test-cases use lazy/conditional require
+        "global-require": "off",
         // reason - enforce 4-space indent
         indent: ["error", 4, { SwitchCase: 1 }],
         // reason - enforce 80-column-width limit
@@ -43,6 +64,8 @@ module.exports = {
         // reason - src/api.js uses bitwise-operators
         "no-bitwise": "off",
         "no-cond-assign": ["error", "except-parens"],
+        // reason - test-cases use console.log and console.error
+        "no-console": ["error", { allow: ["error", "log"] }],
         "no-param-reassign": "off",
         "no-throw-literal": "off",
         // reason - parserOptions is set to es5 language-syntax
@@ -61,7 +84,6 @@ module.exports = {
         // single-quotes
         quotes: ["error", "double"],
         // reason - allow top-level "use-strict" in commonjs-modules
-        strict: ["error", "safe"],
-        "vars-on-top": "off"
+        strict: ["error", "safe"]
     }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,7 +27,6 @@ module.exports = {
         "/test/test_database.js",
         "/test/test_errors.js",
         "/test/test_extension_functions.js",
-        "/test/test_functions.js",
         "/test/test_functions_recreate.js",
         "/test/test_issue128.js",
         "/test/test_issue325.js",

--- a/src/api.js
+++ b/src/api.js
@@ -15,6 +15,7 @@
     stackRestore
     stackSave
 */
+/* eslint vars-on-top: 0 */
 
 "use strict";
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,6 +1,7 @@
 /* global initSqlJs */
 /* eslint-env worker */
 /* eslint no-restricted-globals: ["error"] */
+/* eslint vars-on-top: 0 */
 
 "use strict";
 

--- a/test/test_functions.js
+++ b/test/test_functions.js
@@ -1,153 +1,218 @@
-exports.test = function(SQL, assert){
-  var db = new SQL.Database();
-  db.exec("CREATE TABLE test (data); INSERT INTO test VALUES ('Hello World');");
+"use strict";
 
-  // Simple function, appends extra text on a string.
-  function test_function(string_arg) {
-    return "Function called with: " + string_arg;
-  };
+exports.test = function (SQL, assert) {
+    var db;
+    var result;
+    db = new SQL.Database();
+    db.exec(
+        "CREATE TABLE test (data); INSERT INTO test VALUES ('Hello World');"
+    );
 
-  // Register with SQLite.
-  db.create_function("TestFunction", test_function);
-
-  // Use in a query, check expected result.
-  var result = db.exec("SELECT TestFunction(data) FROM test;");
-  var result_str = result[0]["values"][0][0];
-  assert.equal(result_str, "Function called with: Hello World", "Named functions can be registered");
-
-  // 2 arg function, adds two ints together.
-  db.exec("CREATE TABLE test2 (int1, int2); INSERT INTO test2 VALUES (456, 789);");
-
-  function test_add(int1, int2) {
-    return int1 + int2;
-  };
-
-  db.create_function("TestAdd", test_add);
-  result = db.exec("SELECT TestAdd(int1, int2) FROM test2;");
-  result_int = result[0]["values"][0][0];
-  assert.equal(result_int, 1245, "Multiple argument functions can be registered");
-
-  // Binary data function, tests which byte in a column is set to 0
-  db.exec("CREATE TABLE test3 (data); INSERT INTO test3 VALUES (x'6100ff'), (x'ffffff00ffff');");
-
-  function test_zero_byte_index(data) {
-    // Data is a Uint8Array
-    for (var i=0; i<data.length; i++) {
-      if (data[i] === 0) {
-        return i;
-      }
+    // Simple function, appends extra text on a string.
+    function test_function(string_arg) {
+        return "Function called with: " + string_arg;
     }
-    return -1;
-  };
 
-  db.create_function("TestZeroByteIndex", test_zero_byte_index);
-  result = db.exec("SELECT TestZeroByteIndex(data) FROM test3;");
-  result_int0 = result[0]["values"][0][0];
-  result_int1 = result[0]["values"][1][0];
-  assert.equal(result_int0, 1, "Binary data works inside functions");
-  assert.equal(result_int1, 3, "Binary data works inside functions");
+    // Register with SQLite.
+    db.create_function("TestFunction", test_function);
 
-  db.create_function("addOne", function (x) { return x + 1;} );
-  result = db.exec("SELECT addOne(1);");
-  assert.equal(result[0]["values"][0][0], 2, "Accepts anonymous functions");
- 
-  // Test api support of different sqlite types and special values
-  db.create_function("identityFunction", function (x) { return x;} );
-  var verbose=false;
-  function canHandle(testData)
-  {
-    let result={};
-    let ok=true;
-    let sql_value=("sql_value" in testData)?testData.sql_value:(""+testData.value);
-    function simpleEqual(a, b) {return a===b;}
-    let value_equal=("equal" in testData)?testData.equal:simpleEqual;
-    db.create_function("CheckTestValue", function (x) {return value_equal(testData.value,x)?12345:5678;});
-    db.create_function("GetTestValue", function () {return testData.value; });  
-    // Check sqlite to js value conversion
-    result = db.exec("SELECT CheckTestValue("+sql_value+")==12345"); 
-    if(result[0]["values"][0][0]!=1)
-    {
-      if(verbose)
-        assert.ok(false, "Can accept "+testData.info);
-      ok=false;
+    // Use in a query, check expected result.
+    result = db.exec("SELECT TestFunction(data) FROM test;");
+    assert.equal(
+        result[0]["values"][0][0],
+        "Function called with: Hello World",
+        "Named functions can be registered"
+    );
+
+    // 2 arg function, adds two ints together.
+    db.exec(
+        "CREATE TABLE test2 (int1, int2); INSERT INTO test2 VALUES (456, 789);"
+    );
+
+
+    db.create_function("TestAdd", function (int1, int2) {
+        return int1 + int2;
+    });
+    result = db.exec("SELECT TestAdd(int1, int2) FROM test2;");
+    assert.equal(
+        result[0]["values"][0][0],
+        1245,
+        "Multiple argument functions can be registered"
+    );
+
+    // Binary data function, tests which byte in a column is set to 0
+    db.exec(
+        "CREATE TABLE test3 (data);\n"
+        + "INSERT INTO test3 VALUES (x'6100ff'), (x'ffffff00ffff');\n"
+    );
+
+    function test_zero_byte_index(data) {
+        var i;
+        // Data is a Uint8Array
+        for (i = 0; i < data.length; i += 1) {
+            if (data[i] === 0) {
+                return i;
+            }
+        }
+        return -1;
     }
-    // Check js to sqlite value conversion
-    result = db.exec("SELECT GetTestValue()");
-    if(!value_equal(result[0]["values"][0][0],testData.value))
-    {
-      if(verbose)
-        assert.ok(false, "Can return "+testData.info);
-      ok=false;
-    } 
-    // Check sqlite to sqlite value conversion (identityFunction(x)==x)
-    if(sql_value!=="null")
-    {
-      result = db.exec("SELECT identityFunction("+sql_value+")="+sql_value); 
-    }else
-    {
-      result = db.exec("SELECT identityFunction("+sql_value+") is null"); 
-    }
-    if(result[0]["values"][0][0]!=1)
-    {
-      if(verbose)
-        assert.ok(false, "Can pass "+testData.info);
-      ok=false;
-    } 
-    return ok;
-  }
-  
-  function numberEqual(a, b) {
-      return (+a)===(+b);
-  }
-  
-  function blobEqual(a, b) {
-      if(((typeof a)!="object")||(!a)||((typeof b)!="object")||(!b)) return false;
-      if (a.byteLength !== b.byteLength) return false;
-      return a.every((val, i) => val === b[i]);
-  }
-  
-  [
-    {info:"null",value:null}, // sqlite special value null
-    {info:"false",value:false,sql_value:"0",equal:numberEqual}, // sqlite special value (==false)
-    {info:"true", value:true,sql_value:"1",equal:numberEqual}, // sqlite special value (==true)
-    {info:"integer 0",value:0}, // sqlite special value (==false)
-    {info:"integer 1",value:1}, // sqlite special value (==true)
-    {info:"integer -1",value:-1},
-    {info:"long integer 5e+9",value:5000000000}, // int64
-    {info:"long integer -5e+9",value:-5000000000}, // negative int64
-    {info:"double",value:0.5},
-    {info:"string",value:"Test",sql_value:"'Test'"},
-    {info:"empty string",value:"",sql_value:"''"},
-    {info:"unicode string",value:"\uC7B8",sql_value:"CAST(x'EC9EB8' AS TEXT)"}, // unicode-hex: C7B8 utf8-hex: EC9EB8
-    {info:"blob",value:new Uint8Array([0xC7,0xB8]),sql_value:"x'C7B8'",equal:blobEqual},
-    {info:"empty blob",value:new Uint8Array([]),sql_value:"x''",equal:blobEqual}
-  ].forEach(function(testData)
-  {
-    assert.ok(canHandle(testData),"Can handle "+testData.info);
-  });
-   
-  db.create_function("throwFunction", function () { throw "internal exception"; return 5;} );    
-  assert.throws(function(){db.exec("SELECT throwFunction()");},/internal exception/, "Can handle internal exceptions");
-  
-  db.create_function("customeObjectFunction", function () { return {test:123};} );    
-  assert.throws(function(){db.exec("SELECT customeObjectFunction()");},/Wrong API use/, "Reports wrong API use");
 
-  db.close();
+    db.create_function("TestZeroByteIndex", test_zero_byte_index);
+    result = db.exec("SELECT TestZeroByteIndex(data) FROM test3;");
+    assert.equal(
+        result[0]["values"][0][0],
+        1,
+        "Binary data works inside functions"
+    );
+    assert.equal(
+        result[0]["values"][1][0],
+        3,
+        "Binary data works inside functions"
+    );
+
+    db.create_function("addOne", function (x) { return x + 1; });
+    result = db.exec("SELECT addOne(1);");
+    assert.equal(result[0]["values"][0][0], 2, "Accepts anonymous functions");
+
+    // Test api support of different sqlite types and special values
+    db.create_function("identityFunction", function (x) { return x; });
+    function canHandle(testData) {
+        var ok;
+        var result2;
+        var sql_value;
+        var value_equal;
+        result2 = {};
+        ok = true;
+        sql_value = (
+            ("sql_value" in testData)
+                ? testData.sql_value
+                : ("" + testData.value)
+        );
+        value_equal = (
+            "equal" in testData
+                ? testData.equal
+                : function (a, b) {
+                    return a === b;
+                }
+        );
+        db.create_function("CheckTestValue", function (x) {
+            return value_equal(testData.value, x) ? 12345 : 5678;
+        });
+        db.create_function("GetTestValue", function () {
+            return testData.value;
+        });
+        // Check sqlite to js value conversion
+        result2 = db.exec("SELECT CheckTestValue(" + sql_value + ")==12345");
+        if (result2[0]["values"][0][0] !== 1) {
+            ok = false;
+        }
+        // Check js to sqlite value conversion
+        result2 = db.exec("SELECT GetTestValue()");
+        if (!value_equal(result2[0]["values"][0][0], testData.value)) {
+            ok = false;
+        }
+        // Check sqlite to sqlite value conversion (identityFunction(x)==x)
+        if (sql_value !== "null") {
+            result2 = db.exec(
+                "SELECT identityFunction(" + sql_value + ")=" + sql_value
+            );
+        } else {
+            result2 = db.exec(
+                "SELECT identityFunction(" + sql_value + ") is null"
+            );
+        }
+        if (result2[0]["values"][0][0] !== 1) {
+            ok = false;
+        }
+        return ok;
+    }
+
+    function numberEqual(a, b) {
+        return (+a) === (+b);
+    }
+
+    function blobEqual(a, b) {
+        if (
+            ((typeof a) !== "object")
+            || (!a)
+            || ((typeof b) !== "object")
+            || (!b)
+        ) {
+            return false;
+        }
+        if (a.byteLength !== b.byteLength) return false;
+        return a.every(function (val, i) {
+            return val === b[i];
+        });
+    }
+
+    [
+        // sqlite special value null
+        { info: "null", value: null },
+        // sqlite special value (==false)
+        {
+            info: "false", value: false, sql_value: "0", equal: numberEqual
+        },
+        // sqlite special value (==true)
+        {
+            info: "true", value: true, sql_value: "1", equal: numberEqual
+        },
+        { info: "integer 0", value: 0 }, // sqlite special value (==false)
+        { info: "integer 1", value: 1 }, // sqlite special value (==true)
+        { info: "integer -1", value: -1 },
+        { info: "long integer 5e+9", value: 5000000000 }, // int64
+        { info: "long integer -5e+9", value: -5000000000 }, // negative int64
+        { info: "double", value: 0.5 },
+        { info: "string", value: "Test", sql_value: "'Test'" },
+        { info: "empty string", value: "", sql_value: "''" },
+        // unicode-hex: C7B8 utf8-hex: EC9EB8
+        {
+            info: "unicode string",
+            value: "\uC7B8",
+            sql_value: "CAST(x'EC9EB8' AS TEXT)"
+        },
+        {
+            info: "blob",
+            value: new Uint8Array([0xC7, 0xB8]),
+            sql_value: "x'C7B8'",
+            equal: blobEqual
+        },
+        {
+            info: "empty blob",
+            value: new Uint8Array([]),
+            sql_value: "x''",
+            equal: blobEqual
+        }
+    ].forEach(function (testData) {
+        assert.ok(canHandle(testData), "Can handle " + testData.info);
+    });
+
+    db.create_function("throwFunction", function () {
+        throw "internal exception";
+    });
+    assert.throws(function () {
+        db.exec("SELECT throwFunction()");
+    }, /internal exception/, "Can handle internal exceptions");
+
+    db.create_function("customeObjectFunction", function () {
+        return { test: 123 };
+    });
+    assert.throws(function () {
+        db.exec("SELECT customeObjectFunction()");
+    }, /Wrong API use/, "Reports wrong API use");
+
+    db.close();
 };
 
-if (module == require.main) {
-	const target_file = process.argv[2];
-  const sql_loader = require('./load_sql_lib');
-  sql_loader(target_file).then((sql)=>{
-    require('test').run({
-      'test functions': function(assert, done){
-        exports.test(sql, assert, done);
-      }
+if (module === require.main) {
+    process.on("unhandledRejection", function (r) {
+        throw r;
     });
-  })
-  .catch((e)=>{
-    console.error(e);
-    assert.fail(e);
-  });
+    require("./load_sql_lib")(process.argv[2]).then(function (sql) {
+        return require("test").run({
+            "test functions": function (assert, done) {
+                exports.test(sql, assert, done);
+            }
+        });
+    });
 }
-

--- a/test/test_worker.js
+++ b/test/test_worker.js
@@ -1,117 +1,201 @@
 // TODO: Instead of using puppeteer, we could use the new Node 11 workers via
 // node --experimental-worker test/all.js
 // Then we could do this:
-//const { Worker } = require('worker_threads');
-// But it turns out that the worker_threads interface is just different enough not to work.
-var puppeteer = require("puppeteer");
-var path = require("path");
+// const { Worker } = require('worker_threads');
+// But it turns out that the worker_threads interface is just different enough
+// not to work.
+
+"use strict";
+
 var fs = require("fs");
-
-class Worker {
-  constructor(handle) {
-    this.handle = handle;
-  }
-  static async fromFile(file) {
-    const browser = await puppeteer.launch();
-    const page = await browser.newPage();
-    const source = fs.readFileSync(file, 'utf8');
-    const worker = await page.evaluateHandle(x => {
-      const url = URL.createObjectURL(new Blob([x]), { type: 'application/javascript; charset=utf-8' });
-      return new Worker(url);
-    }, source);
-    return new Worker(worker);
-  }
-  async postMessage(msg) {
-    return await this.handle.evaluate((worker, msg) => {
-      return new Promise((accept, reject) => {
-        setTimeout(reject, 20000, new Error("time out"));
-        worker.onmessage = evt => accept(evt.data);
-        worker.onerror = reject;
-        worker.postMessage(msg);
-      })
-    }, msg);
-  }
-}
-
-exports.test = async function test(SQL, assert) {
-  var target = process.argv[2];
-  var file = target ? "sql-" + target : "sql-wasm";
-  if (file.indexOf('wasm') > -1 || file.indexOf('memory-growth') > -1) {
-    console.error("Skipping worker test for " + file + ". Not implemented yet");
-    return;
-  };
-  // If we use puppeteer, we need to pass in this new cwd as the root of the file being loaded:
-  const filename = "../dist/worker." + file + ".js";
-  var worker = await Worker.fromFile(path.join(__dirname, filename));
-  var data = await worker.postMessage({ id: 1, action: 'open' });
-  assert.strictEqual(data.id, 1, "Return the given id in the correct format");
-  assert.deepEqual(data, { id: 1, ready: true }, 'Correct data answered to the "open" query');
-
-  data = await worker.postMessage({
-    id: 2,
-    action: 'exec',
-    params: {
-        ":num2": 2,
-        "@str2": 'b',
-        // test_worker.js has issue message-passing Uint8Array
-        // but it works fine in real-world browser-usage
-        // "$hex2": new Uint8Array([0x00, 0x42]),
-        ":num3": 3,
-        "@str3": 'c'
-        // "$hex3": new Uint8Array([0x00, 0x44])
-    },
-    sql: "CREATE TABLE test (num, str, hex);" +
-      "INSERT INTO test VALUES (1, 'a', x'0042');" +
-      "INSERT INTO test VALUES (:num2, @str2, x'0043');" +
-      // test passing params split across multi-statement "exec"
-      "INSERT INTO test VALUES (:num3, @str3, x'0044');" +
-      "SELECT * FROM test;"
-  });
-  assert.strictEqual(data.id, 2, "Correct id");
-  // debug error
-  assert.strictEqual(data.error, undefined, data.error);
-  var results = data.results;
-  assert.ok(Array.isArray(results), 'Correct result type');
-  assert.strictEqual(results.length, 1, 'Expected exactly 1 table');
-  var table = results[0];
-  assert.strictEqual(typeof table, 'object', 'Type of the returned table');
-  assert.deepEqual(table.columns, ['num', 'str', 'hex'], 'Reading column names');
-  assert.strictEqual(table.values[0][0], 1, 'Reading number');
-  assert.strictEqual(table.values[0][1], 'a', 'Reading string');
-  assert.deepEqual(obj2array(table.values[0][2]), [0x00, 0x42], 'Reading BLOB byte');
-  assert.strictEqual(table.values[1][0], 2, 'Reading number');
-  assert.strictEqual(table.values[1][1], 'b', 'Reading string');
-  assert.deepEqual(obj2array(table.values[1][2]), [0x00, 0x43], 'Reading BLOB byte');
-  assert.strictEqual(table.values[2][0], 3, 'Reading number');
-  assert.strictEqual(table.values[2][1], 'c', 'Reading string');
-  assert.deepEqual(obj2array(table.values[2][2]), [0x00, 0x44], 'Reading BLOB byte');
-
-  data = await worker.postMessage({ action: 'export' });
-  var header = "SQLite format 3\0";
-  var actual = "";
-  for (let i = 0; i < header.length; i++) actual += String.fromCharCode(data.buffer[i]);
-  assert.equal(actual, header, 'Data returned is an SQLite database file');
-
-  // test worker properly opens db after closing
-  await worker.postMessage({ action: "close" });
-  await worker.postMessage({ action: "open" });
-  data = await worker.postMessage({ action: "exec", sql: "SELECT 1" });
-  assert.deepEqual(data.results, [{"columns":["1"],"values":[[1]]}]);
-}
+var path = require("path");
+var puppeteer = require("puppeteer");
 
 function obj2array(obj) {
-  var buffer = []
-  for (var p in obj) { buffer[p] = obj[p] }
-  return buffer;
+    var buffer = [];
+    Object.entries(obj).forEach(function (elem) {
+        buffer[elem[0]] = elem[1];
+    });
+    return buffer;
 }
 
-if (module == require.main) {
-  process.on('unhandledRejection', r => console.log(r));
+function Worker(handle) {
+    this.handle = handle;
+}
 
-  require('test').run({
-    'test worker': function (assert, done) {
-      exports.test(null, assert).then(done);
+Worker.fromFile = function (file) {
+    return puppeteer.launch({
+        // uncomment line below if running test inside docker as root
+        // args: ["--no-sandbox"]
+    }).then(function (browser) {
+        return browser.newPage();
+    }).then(function (page) {
+        return page.evaluateHandle(function (x) {
+            return new Worker(URL.createObjectURL(
+                new Blob([x]),
+                { type: "application/javascript; charset=utf-8" }
+            ));
+        }, fs.readFileSync(file, "utf8"));
+    }).then(function (worker) {
+        return new Worker(worker);
+    });
+};
+
+Worker.prototype.postMessage = function (msg) {
+    return this.handle.evaluate(function (worker, msg2) {
+        return new Promise(function (accept, reject) {
+            setTimeout(
+                reject,
+                20000,
+                new Error("time out")
+            );
+            worker.onmessage = function (evt) {
+                return accept(evt.data);
+            };
+            worker.onerror = reject;
+            worker.postMessage(msg2);
+        });
+    }, msg);
+};
+
+exports.test = function test(SQL, assert) {
+    var file;
+    var promise;
+    var worker;
+    promise = Promise.resolve();
+    file = (
+        process.argv[2]
+            ? "sql-" + process.argv[2]
+            : "sql-wasm"
+    );
+    if (file.indexOf("wasm") > -1 || file.indexOf("memory-growth") > -1) {
+        console.error(
+            "Skipping worker test for " + file + ". Not implemented yet"
+        );
+        return promise;
     }
-  });
+    // If we use puppeteer, we need to pass in this new cwd as the root
+    // of the file being loaded:
+    promise = promise.then(function () {
+        return Worker.fromFile(
+            path.join(__dirname, "../dist/worker." + file + ".js")
+        );
+    });
+    promise = promise.then(function (data) {
+        worker = data;
+        return worker.postMessage({ id: 1, action: "open" });
+    });
+    promise = promise.then(function (data) {
+        assert.strictEqual(
+            data.id,
+            1,
+            "Return the given id in the correct format"
+        );
+        assert.deepEqual(
+            data,
+            { id: 1, ready: true },
+            "Correct data answered to the \"open\" query"
+        );
+        return worker.postMessage({
+            id: 2,
+            action: "exec",
+            params: {
+                ":num2": 2,
+                "@str2": "b",
+                // test_worker.js has issue message-passing Uint8Array
+                // but it works fine in real-world browser-usage
+                // "$hex2": new Uint8Array([0x00, 0x42]),
+                ":num3": 3,
+                "@str3": "c"
+            // "$hex3": new Uint8Array([0x00, 0x44])
+            },
+            sql: "CREATE TABLE test (num, str, hex);"
+          + "INSERT INTO test VALUES (1, 'a', x'0042');"
+          + "INSERT INTO test VALUES (:num2, @str2, x'0043');"
+          // test passing params split across multi-statement "exec"
+          + "INSERT INTO test VALUES (:num3, @str3, x'0044');"
+          + "SELECT * FROM test;"
+        });
+    });
+    promise = promise.then(function (data) {
+        var results;
+        var table;
+        assert.strictEqual(data.id, 2, "Correct id");
+        // debug error
+        assert.strictEqual(data.error, undefined, data.error);
+        results = data.results;
+        assert.ok(Array.isArray(results), "Correct result type");
+        assert.strictEqual(results.length, 1, "Expected exactly 1 table");
+        table = results[0];
+        assert.strictEqual(
+            typeof table,
+            "object",
+            "Type of the returned table"
+        );
+        assert.deepEqual(
+            table.columns,
+            ["num", "str", "hex"],
+            "Reading column names"
+        );
+        assert.strictEqual(table.values[0][0], 1, "Reading number");
+        assert.strictEqual(table.values[0][1], "a", "Reading string");
+        assert.deepEqual(
+            obj2array(table.values[0][2]),
+            [0x00, 0x42],
+            "Reading BLOB byte"
+        );
+        assert.strictEqual(table.values[1][0], 2, "Reading number");
+        assert.strictEqual(table.values[1][1], "b", "Reading string");
+        assert.deepEqual(
+            obj2array(table.values[1][2]),
+            [0x00, 0x43],
+            "Reading BLOB byte"
+        );
+        assert.strictEqual(table.values[2][0], 3, "Reading number");
+        assert.strictEqual(table.values[2][1], "c", "Reading string");
+        assert.deepEqual(
+            obj2array(table.values[2][2]),
+            [0x00, 0x44],
+            "Reading BLOB byte"
+        );
+        return worker.postMessage({ action: "export" });
+    });
+    promise = promise.then(function (data) {
+        var actual;
+        var header;
+        var i;
+        actual = "";
+        header = "SQLite format 3\0";
+        for (i = 0; i < header.length; i += 1) {
+            actual += String.fromCharCode(data.buffer[i]);
+        }
+        assert.equal(
+            actual,
+            header,
+            "Data returned is an SQLite database file"
+        );
+        // test worker properly opens db after closing
+        return worker.postMessage({ action: "close" });
+    });
+    promise = promise.then(function () {
+        return worker.postMessage({ action: "open" });
+    });
+    promise = promise.then(function () {
+        return worker.postMessage({ action: "exec", sql: "SELECT 1" });
+    });
+    promise = promise.then(function (data) {
+        assert.deepEqual(data.results, [{ columns: ["1"], values: [[1]] }]);
+    });
+    return promise;
+};
 
+if (module === require.main) {
+    process.on("unhandledRejection", function (r) {
+        throw r;
+    });
+    require("test").run({
+        "test worker": function (assert, done) {
+            exports.test(null, assert).then(done);
+        }
+    });
 }


### PR DESCRIPTION
this pull-request currently has 4 commits:

#### commit 1
    - first-pass to eslint directory /test/ (exclude /test/test_worker.js)
    - enforce 80-column max-width
    - use 4-space indent
    - replace fat-arrow (=>) with function
    - replace let/const with var
    - replace == with === and != with !==
    - replace x++ with x += 1
    - eslint rule changes:
    ```diff
    +    "global-require": "off", // test-code has embedded/non-top-level require(...)
    +    "func-names": "off", // needed when replacing fat-arrows with anonymous-functions
    +    "import/no-dynamic-require": "off", // test-code uses dynamic-require
    +    "max-len": ["error", { code: 80 }], // 80-column
    +    "no-console": ["error", { allow: ["error", "log"] }], // console.error
    -    strict: ["error", "function"],
    +    strict: ["error", "safe"], // top-level use-strict in commonjs-module
    ```

#### commit 2
    - document reason for each eslint-rule

#### commit 3
    - eslint /test/test_worker.js

#### commit 4
    - tighten eslint-rule "vars-on-top": "on"
    - to prevent test-writers from haphazardly leaving var-statements all over test-code

not sure if others feel commit 4 is acceptably motivated or not.  but am open to revert/change it (or any of the other commits).
