### PR TITLE
examples: update start_local_server to python3

### DIFF
--- a/examples/start_local_server.py
+++ b/examples/start_local_server.py
@@ -1,15 +1,21 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-import BaseHTTPServer, SimpleHTTPServer, os
+import http.server
+import os
 
 # We need to host from the root because we are going to be requesting files inside of dist
-os.chdir('../')
-port=8081
-print "Running on port %d" % port
+os.chdir("../")
+port = 8081
+print("Running on port %d" % port)
 
-SimpleHTTPServer.SimpleHTTPRequestHandler.extensions_map['.wasm'] = 'application/wasm'
+http.server.SimpleHTTPRequestHandler.extensions_map[".wasm"] = "application/wasm"
 
-httpd = BaseHTTPServer.HTTPServer(('localhost', port), SimpleHTTPServer.SimpleHTTPRequestHandler)
+httpd = http.server.HTTPServer(
+    ("localhost", port), http.server.SimpleHTTPRequestHandler
+)
 
-print "Mapping \".wasm\" to \"%s\"" % SimpleHTTPServer.SimpleHTTPRequestHandler.extensions_map['.wasm']
+print(
+    'Mapping ".wasm" to "%s"'
+    % http.server.SimpleHTTPRequestHandler.extensions_map[".wasm"]
+)
 httpd.serve_forever()


### PR DESCRIPTION
Python 2 EOL'd in January 2020, and generally is vanishing from Linux
distros.  The code is simple enough that a 2to3 pass is sufficient to
update it to a working state on modern Python.  A pass through the
“black” tool was also used just to maintain a standard style.