### PR TITLE
Change exec(...) to return column names for empty result sets

### DIFF
--- a/src/exported_functions.json
+++ b/src/exported_functions.json
@@ -13,6 +13,7 @@
 "_sqlite3_bind_int",
 "_sqlite3_bind_parameter_index",
 "_sqlite3_step",
+"_sqlite3_column_count",
 "_sqlite3_data_count",
 "_sqlite3_column_double",
 "_sqlite3_column_text",

--- a/test/test_database.js
+++ b/test/test_database.js
@@ -37,8 +37,10 @@ exports.test = function(SQL, assert, done) {
   db2.close();
 
   db = new SQL.Database();
-  assert.deepEqual(db.exec("SELECT * FROM sqlite_master"),
-                   [],
+  result = db.exec("SELECT * FROM sqlite_master");
+  assert.strictEqual(result.length, 1,
+                     "db.exec() should return array length 1 for single select");
+  assert.deepEqual(result[0].values, [],
                    "Newly created databases should be empty");
   // Testing db.each
   db.run("CREATE TABLE test (a,b); INSERT INTO test VALUES (1,'a'),(2,'b')");

--- a/test/test_issue388.js
+++ b/test/test_issue388.js
@@ -1,0 +1,51 @@
+exports.test = function(sql, assert){
+  "use strict";
+  // Create a database
+  var db = new sql.Database();
+  db.run("CREATE TABLE test (foo);");
+
+  // getColumnNames() on empty table
+  var stmt = db.prepare("SELECT * FROM test;");
+  assert.deepEqual(stmt.getColumnNames(), ["foo"],
+                   "getColumnNames() should work without step() & with empty result set");
+  stmt.free();
+
+  // Select/insert/select gives correct 2 element result
+  result = db.exec(
+    "SELECT * FROM test; "
+    + "INSERT INTO test VALUES (42); "
+    + "SELECT * FROM test"
+  );
+
+  assert.deepEqual(result,
+    [
+      {
+        columns: ["foo"],
+        values: []
+      }, {
+        columns: ["foo"],
+        values: [[42]]
+      },
+    ], 
+    "Return value of exec with 2 selects should be length 2 and contain correct values"
+  );
+
+  // Close the database and all associated statements
+  db.close();
+};
+
+if (module == require.main) {
+  const target_file = process.argv[2];
+  const sql_loader = require('./load_sql_lib');
+  sql_loader(target_file).then((sql)=>{
+    require('test').run({
+      'test issue388': function(assert){
+        exports.test(sql, assert);
+      }
+    });
+  })
+  .catch((e)=>{
+    console.error(e);
+    assert.fail(e);
+  });
+}

--- a/test/test_transactions.js
+++ b/test/test_transactions.js
@@ -12,8 +12,10 @@ exports.test = function(SQL, assert){
   db.exec("ROLLBACK;");
 
   var res = db.exec("SELECT data FROM test WHERE data = 4;");
+  assert.strictEqual(res.length, 1,
+                     "db.exec() should return array length 1 for single select");
   var expectedResult =  [];
-  assert.deepEqual(res, expectedResult, "transaction rollbacks work");
+  assert.deepEqual(res[0].values, expectedResult, "transaction rollbacks work");
 
   // Open a transaction
   db.exec("BEGIN TRANSACTION;");


### PR DESCRIPTION
Currently exec(...) will not put anything in its results array for a SELECT query which returns no results. This is not ideal. Say I run 3 SELECT queries, and 1 returns an empty result set. How do I know which query isn't included in the results array? With this change, you can always tell what the size of the results array will be just by inspecting the query. I have also changed getColumnNames(...) to work for empty result sets by using sqlite3_column_count instead of sqlite3_data_count.