### PR TITLE
Add IDBFS support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,8 @@ EMFLAGS = \
 	-s EXPORTED_FUNCTIONS=@src/exported_functions.json \
 	-s EXTRA_EXPORTED_RUNTIME_METHODS=@src/exported_runtime_methods.json \
 	-s SINGLE_FILE=0 \
+	-s FORCE_FILESYSTEM=1 \
+	-lidbfs.js \
 	-s NODEJS_CATCH_EXIT=0
 
 EMFLAGS_ASM = \
@@ -52,8 +54,7 @@ EMFLAGS_OPTIMIZED= \
 	-s INLINING_LIMIT=50 \
 	-O3 \
 	-flto \
-	--llvm-lto 1 \
-	--closure 1
+	--llvm-lto 1
 
 EMFLAGS_DEBUG = \
 	-s INLINING_LIMIT=10 \

--- a/src/api.js
+++ b/src/api.js
@@ -621,13 +621,18 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
     * @memberof module:SqlJs
     * Open a new database either by creating a new one or opening an existing
     * one stored in the byte array passed in first argument
-    * @param {number[]} data An array of bytes representing
-    * an SQLite database file
+    * @param {number[]|string} data An array of bytes representing
+    * an SQLite database file. Alternatively, a file path representing the
+    * file to load if using IDBFS.
     */
     function Database(data) {
         this.filename = "dbfile_" + (0xffffffff * Math.random() >>> 0);
         if (data != null) {
-            FS.createDataFile("/", this.filename, data, true, true);
+            if (typeof data === "string") {
+                this.filename = data;
+            } else {
+                FS.createDataFile("/", this.filename, data, true, true);
+            }
         }
         this.handleError(sqlite3_open(this.filename, apiTemp));
         this.db = getValue(apiTemp, "i32");

--- a/src/exported_runtime_methods.json
+++ b/src/exported_runtime_methods.json
@@ -2,5 +2,8 @@
 "cwrap",
 "stackAlloc",
 "stackSave",
-"stackRestore"
+"stackRestore",
+"FS",
+"MEMFS",
+"IDBFS"
 ]


### PR DESCRIPTION
This PR adds support for IDBFS by:
 - Enabling IDBFS support at compile time.
 - Exporting the filesystem objects at runtime so things like `FS.syncfs` can be called.
 - Modifying the `Database` API to accept a `string` in addition to a `Uint8Array` in its constructor, which sets `this.filename` accordingly. This is to allow for backwards compatibility. Previously, passing strings would throw.

There's one major shortcoming with this PR which is that I have to remove `--closure 1` on `EMFLAGS_OPTIMIZED` otherwise **some** methods on `FS` are minified (`mount` and `syncfs` are affected). I'm unsure why the closure compiler is doing this.

To use IDBFS, users need to:
```js
const initSqlJs = require('sql.js');
const SQL = await initSqlJs();

SQL.FS.mkdir("/idb");
SQL.FS.mount(SQL.IDBFS, {}, "/idb");
// load what was previously stored in IndexedDB
// wait for syncfs callback to be invoked to know when it is ready.
SQL.FS.syncfs(true, function(err) { .... });
// uses existing content or a new file is made
const db = new SQL.Database("/idb/myfilename.db");

// ... do some work ...

// save to IndexedDB, wait for callback to be invoked to know when it is complete
SQL.FS.syncfs(false, function(err) { .... });
```

IDBFS support is preferable in some cases over `Database.export` as that function will close the database/clear prepared statements and make the `Database` subsequently unusable. `SQL.FS.syncfs` however will not close the database.

Fixes #302 but for clarity: this is just writing files, so is database-level scoped, not table/row level scoped.