### PR TITLE
Add documentation for enabling extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,3 +285,17 @@ For each [release](https://github.com/sql-js/sql.js/releases/), you will find a 
 
 - Install the EMSDK, [as described here](https://emscripten.org/docs/getting_started/downloads.html)
 - Run `npm run rebuild`
+
+In order to enable extensions like JSON1 or FTS5, change the CFLAGS in the [Makefile](Makefile) and rebuild:
+
+``` diff
+CFLAGS = \
+        -O2 \
+        -DSQLITE_OMIT_LOAD_EXTENSION \
+        -DSQLITE_DISABLE_LFS \
+        -DSQLITE_ENABLE_FTS3 \
+        -DSQLITE_ENABLE_FTS3_PARENTHESIS \
++       -DSQLITE_ENABLE_FTS5 \
++       -DSQLITE_ENABLE_JSON1 \
+        -DSQLITE_THREADSAFE=0
+```


### PR DESCRIPTION
I thought this might be a welcome change if someone searches for JSON or FTS on the landing page they’ll find this and get to recompiling instead of requesting it to be included. Worked flawlessly here, I’m impressed, thank you! And feel free to close if you think otherwise, of course.