### PR TITLE
Export improvements

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -859,14 +859,12 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
     Database.prototype["export"] = function exportDatabase() {
         var binaryDb;
         Object.values(this.statements).forEach(function each(stmt) {
-            stmt["free"]();
+            stmt["reset"]();
         });
-        Object.values(this.functions).forEach(removeFunction);
-        this.functions = {};
-        this.handleError(sqlite3_close_v2(this.db));
-        binaryDb = FS.readFile(this.filename, { encoding: "binary" });
-        this.handleError(sqlite3_open(this.filename, apiTemp));
-        this.db = getValue(apiTemp, "i32");
+        var exportFilename = "export_" + (0xffffffff * Math.random() >>> 0);
+        this.exec("VACUUM INTO ?", [exportFilename]);
+        binaryDb = FS.readFile(exportFilename, { encoding: "binary" });
+        FS.unlink(exportFilename);
         return binaryDb;
     };
 


### PR DESCRIPTION
Based on #302 I’ve been trying to improve export, and this has lead me on a path™. Have you considered using one of these options?

1. [`VACUUM INTO`](https://www.sqlite.org/lang_vacuum.html#vacuum_with_an_into_clause) a temporary file that’s read, unlinked and returned
2. Using sqlite’s [Online Backup API](https://www.sqlite.org/backup.html) to create a copy that’s returned
3. Duplicating and returning the working memory via [deserialize](https://www.sqlite.org/c3ref/serialize.html)

In this PR, I’m giving (1) a shot. I’m very interested to hear what you have to say. Ultimately, option (2) might be better suited for a generic `export` function since it doesn’t incur a VACUUM, and I will most likely give that a try as well.

On a related note: Since the current filesystem is MEMFS, have you considered just using an in-memory database instead? Right now, sqlite believes it’s writing to a persistent filesystem, but MEMFS is backed by memory. Since everything’s happening in-memory anyway, why not use sqlite’s native memory-backed mechanics and drop the MEMFS indirection along the way?

I have no experience with IDBFS (#397), and boy would I prefer if we had something like [NativeIO](https://github.com/fivedots/nativeio-explainer).

Some notes to self:

- [ ] Add test for #159
- [ ] Test using bound statements after export
- [ ] Test using JS function after export