### PR TITLE
replace all obsolete occurrences of http-link "github.com/kripken/sql.js" with "github.com/sql-js/sql.js"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ CFLAGS = \
 
 # When compiling to WASM, enabling memory-growth is not expected to make much of an impact, so we enable it for all builds
 # Since tihs is a library and not a standalone executable, we don't want to catch unhandled Node process exceptions
-# So, we do : `NODEJS_CATCH_EXIT=0`, which fixes issue: https://github.com/kripken/sql.js/issues/173 and https://github.com/kripken/sql.js/issues/262
+# So, we do : `NODEJS_CATCH_EXIT=0`, which fixes issue: https://github.com/sql-js/sql.js/issues/173 and https://github.com/sql-js/sql.js/issues/262
 EMFLAGS = \
 	--memory-init-file 0 \
 	-s RESERVED_FUNCTION_POINTERS=64 \

--- a/examples/GUI/index.html
+++ b/examples/GUI/index.html
@@ -12,7 +12,7 @@
 
 <body>
   <!-- Github ribbon -->
-  <a href="https://github.com/kripken/sql.js"><img style="position: absolute; top: 0; left: 0; border: 0;"
+  <a href="https://github.com/sql-js/sql.js"><img style="position: absolute; top: 0; left: 0; border: 0;"
       src="https://camo.githubusercontent.com/82b228a3648bf44fc1163ef44c62fcc60081495e/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f6c6566745f7265645f6161303030302e706e67"
       alt="Fork me on GitHub"
       data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_left_red_aa0000.png"></a>
@@ -59,7 +59,7 @@ SELECT name,hired_on FROM employees ORDER BY hired_on;</textarea>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.46.0/mode/sql/sql.min.js"></script>
 
   <footer>
-    Original work by kripken (<a href='https://github.com/kripken/sql.js'>sql.js</a>).
+    Original work by kripken (<a href='https://github.com/sql-js/sql.js'>sql.js</a>).
     C to Javascript compiler by kripken (<a href='https://github.com/kripken/emscripten'>emscripten</a>).
     Project now maintained by <a href='https://github.com/lovasoa'>lovasoa</a>
   </footer>

--- a/test/disabled_test_memory_leak_on_error.js
+++ b/test/disabled_test_memory_leak_on_error.js
@@ -1,4 +1,4 @@
-// See: https://github.com/kripken/sql.js/issues/306
+// See: https://github.com/sql-js/sql.js/issues/306
 exports.test = function(sql, assert) {
   var errors = 0, runs=10000;
   for (var i=0; i<runs; i++) {


### PR DESCRIPTION
 by running shell-command:

$ git grep "github.com/kripken/sql.js" | sed -e "s/:.*//" | sort -u | xargs sed -i "s|github.com/kripken/sql.js|github.com/sql-js/sql.js|g"

also verified the following replaced http-links are valid:
```
https://github.com/sql-js/sql.js/issues/173
https://github.com/sql-js/sql.js/issues/262
https://github.com/sql-js/sql.js
https://github.com/sql-js/sql.js/issues/306
```


this is primarily intended to prevent users from forking the obsolete kripken-stub in the online-demo:
![image](https://user-images.githubusercontent.com/280571/92264988-c24b8d80-eea4-11ea-9887-9a93b0e3218d.png)

