### PR TITLE
replace all obsolete occurrences of http-link "github.com/kripken/sql…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ CFLAGS=-O2 -DSQLITE_OMIT_LOAD_EXTENSION -DSQLITE_DISABLE_LFS -DLONGDOUBLE_TYPE=d
 
 # When compiling to WASM, enabling memory-growth is not expected to make much of an impact, so we enable it for all builds
 # Since tihs is a library and not a standalone executable, we don't want to catch unhandled Node process exceptions
-# So, we do : `NODEJS_CATCH_EXIT=0`, which fixes issue: https://github.com/kripken/sql.js/issues/173 and https://github.com/kripken/sql.js/issues/262
+# So, we do : `NODEJS_CATCH_EXIT=0`, which fixes issue: https://github.com/sql-js/sql.js/issues/173 and https://github.com/sql-js/sql.js/issues/262
 EMFLAGS = \
 	--memory-init-file 0 \
 	-s RESERVED_FUNCTION_POINTERS=64 \

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ xhr.onload = e => {
 };
 xhr.send();
 ```
-See: https://github.com/kripken/sql.js/wiki/Load-a-database-from-the-server
+See: https://github.com/sql-js/sql.js/wiki/Load-a-database-from-the-server
 
 
 ### Use from node.js
@@ -182,7 +182,7 @@ var buffer = new Buffer(data);
 fs.writeFileSync("filename.sqlite", buffer);
 ```
 
-See : https://github.com/kripken/sql.js/blob/master/test/test_node_file.js
+See : https://github.com/sql-js/sql.js/blob/master/test/test_node_file.js
 
 ### Use as web worker
 If you don't want to run CPU-intensive SQL queries in your main application thread,

--- a/documentation/extra/README.md.html
+++ b/documentation/extra/README.md.html
@@ -129,7 +129,7 @@ xhr.onload = function(e) {
   // contents is now [{columns:[&#39;col1&#39;,&#39;col2&#39;,...], values:[[first row], [second row], ...]}]
 };
 xhr.send();
-</code></pre><p>See: <a href="https://github.com/kripken/sql.js/wiki/Load-a-database-from-the-server">https://github.com/kripken/sql.js/wiki/Load-a-database-from-the-server</a></p><h3 id="use-from-node-js">Use from node.js</h3><p><code>sql.js</code> is <a href="https://www.npmjs.org/package/sql.js">hosted on npm</a>. To install it, you can simply run <code>npm install sql.js</code>.
+</code></pre><p>See: <a href="https://github.com/sql-js/sql.js/wiki/Load-a-database-from-the-server">https://github.com/sql-js/sql.js/wiki/Load-a-database-from-the-server</a></p><h3 id="use-from-node-js">Use from node.js</h3><p><code>sql.js</code> is <a href="https://www.npmjs.org/package/sql.js">hosted on npm</a>. To install it, you can simply run <code>npm install sql.js</code>.
 Alternatively, you can simply download the file <code>sql.js</code>, from the download link below.</p><h4 id="read-a-database-from-the-disk-">read a database from the disk:</h4>
 <pre><code class="lang-javascript">var fs = require(&#39;fs&#39;);
 var SQL = require(&#39;sql.js&#39;);
@@ -143,7 +143,7 @@ var db = new SQL.Database(filebuffer);
 var data = db.export();
 var buffer = new Buffer(data);
 fs.writeFileSync(&quot;filename.sqlite&quot;, buffer);
-</code></pre><p>See : <a href="https://github.com/kripken/sql.js/blob/master/test/test_node_file.js">https://github.com/kripken/sql.js/blob/master/test/test_node_file.js</a></p><h3 id="use-as-web-worker">Use as web worker</h3><p>If you don&#39;t want to run CPU-intensive SQL queries in your main application thread,
+</code></pre><p>See : <a href="https://github.com/sql-js/sql.js/blob/master/test/test_node_file.js">https://github.com/sql-js/sql.js/blob/master/test/test_node_file.js</a></p><h3 id="use-as-web-worker">Use as web worker</h3><p>If you don&#39;t want to run CPU-intensive SQL queries in your main application thread,
 you can use the <em>more limited</em> WebWorker API.</p><p>You will need to download <code>worker.sql.js</code></p><p>Example:</p><pre><code class="lang-html">&lt;script&gt;
 var worker = new Worker(&quot;js/worker.sql.js&quot;); // You can find worker.sql.js in this repo
 worker.onmessage = function() {
@@ -165,7 +165,7 @@ worker.postMessage({
     buffer:buf, /*Optional. An ArrayBuffer representing an SQLite Database file*/
 });
 &lt;/script&gt;
-</code></pre><p>See : <a href="https://github.com/kripken/sql.js/blob/master/test/test_worker.js">https://github.com/kripken/sql.js/blob/master/test/test_worker.js</a></p><h2 id="downloads">Downloads</h2>
+</code></pre><p>See : <a href="https://github.com/sql-js/sql.js/blob/master/test/test_worker.js">https://github.com/sql-js/sql.js/blob/master/test/test_worker.js</a></p><h2 id="downloads">Downloads</h2>
 <ul>
 <li>You can download <code>sql.js</code> here : <a href="https://raw.githubusercontent.com/kripken/sql.js/master/js/sql.js">https://raw.githubusercontent.com/kripken/sql.js/master/js/sql.js</a></li>
 <li>And the Web Worker version: <a href="https://raw.githubusercontent.com/kripken/sql.js/master/js/worker.sql.js">https://raw.githubusercontent.com/kripken/sql.js/master/js/worker.sql.js</a></li>

--- a/examples/GUI/index.html
+++ b/examples/GUI/index.html
@@ -12,7 +12,7 @@
 
 <body>
   <!-- Github ribbon -->
-  <a href="https://github.com/kripken/sql.js"><img style="position: absolute; top: 0; left: 0; border: 0;"
+  <a href="https://github.com/sql-js/sql.js"><img style="position: absolute; top: 0; left: 0; border: 0;"
       src="https://camo.githubusercontent.com/82b228a3648bf44fc1163ef44c62fcc60081495e/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f6c6566745f7265645f6161303030302e706e67"
       alt="Fork me on GitHub"
       data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_left_red_aa0000.png"></a>
@@ -59,7 +59,7 @@ SELECT name,hired_on FROM employees ORDER BY hired_on;</textarea>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.46.0/mode/sql/sql.min.js"></script>
 
   <footer>
-    Original work by kripken (<a href='https://github.com/kripken/sql.js'>sql.js</a>).
+    Original work by kripken (<a href='https://github.com/sql-js/sql.js'>sql.js</a>).
     C to Javascript compiler by kripken (<a href='https://github.com/kripken/emscripten'>emscripten</a>).
     Project now maintained by <a href='https://github.com/lovasoa'>lovasoa</a>
   </footer>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ Note: To run these examples locally, see <a href="./examples/readme.md">./exampl
 
 <h2>Source</h2>
 
-<p><a href="https://github.com/kripken/sql.js">Source on Github</a></p>
+<p><a href="https://github.com/sql-js/sql.js">Source on Github</a></p>
 
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
 		"test-wasm": "node test/all.js wasm",
 		"test-wasm-debug": "node test/all.js wasm-debug"
 	},
-	"homepage": "http://github.com/kripken/sql.js",
+	"homepage": "http://github.com/sql-js/sql.js",
 	"repository": {
 		"type": "git",
-		"url": "http://github.com/kripken/sql.js.git"
+		"url": "http://github.com/sql-js/sql.js.git"
 	},
 	"bugs": {
-		"url": "https://github.com/kripken/sql.js/issues",
+		"url": "https://github.com/sql-js/sql.js/issues",
 		"email": "pere.jobs@gmail.com"
 	},
 	"devDependencies": {


### PR DESCRIPTION
….js" with "github.com/sql-js/sql.js" by running shell-command:

$ git grep "github.com/kripken/sql.js" | sed -e "s/:.*//" | sort -u | xargs sed -i "s|github.com/kripken/sql.js|github.com/sql-js/sql.js|g"