### PR TITLE
simplify dist by merging sql-asm-memory-growth.js into sql-asm.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,8 @@ EMFLAGS = \
 	-s NODEJS_CATCH_REJECTION=0
 
 EMFLAGS_ASM = \
-	-s WASM=0
-
-EMFLAGS_ASM_MEMORY_GROWTH = \
 	-s WASM=0 \
+	-s LEGACY_VM_SUPPORT=1 \
 	-s ALLOW_MEMORY_GROWTH=1
 
 EMFLAGS_WASM = \
@@ -90,7 +88,7 @@ dist/sql-wasm-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FI
 	rm out/tmp-raw.js
 
 .PHONY: optimized
-optimized: dist/sql-asm.js dist/sql-wasm.js dist/sql-asm-memory-growth.js
+optimized: dist/sql-asm.js dist/sql-wasm.js
 
 dist/sql-asm.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
 	$(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_ASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
@@ -100,12 +98,6 @@ dist/sql-asm.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(
 
 dist/sql-wasm.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
 	$(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_WASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
-	mv $@ out/tmp-raw.js
-	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
-	rm out/tmp-raw.js
-
-dist/sql-asm-memory-growth.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
-	$(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_ASM_MEMORY_GROWTH) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
 	mv $@ out/tmp-raw.js
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
 	rm out/tmp-raw.js

--- a/README.md
+++ b/README.md
@@ -276,8 +276,7 @@ You can always find the latest published artifacts on https://github.com/sql-js/
 For each [release](https://github.com/sql-js/sql.js/releases/), you will find a file called `sqljs.zip` in the *release assets*. It will contain:
  - `sql-wasm.js` : The Web Assembly version of Sql.js. Minified and suitable for production. Use this. If you use this, you will need to include/ship `sql-wasm.wasm` as well.
  - `sql-wasm-debug.js` : The Web Assembly, Debug version of Sql.js. Larger, with assertions turned on. Useful for local development. You will need to include/ship `sql-wasm-debug.wasm` if you use this.
- - `sql-asm.js` : The older asm.js version of Sql.js. Slower and larger. Provided for compatibility reasons.
- - `sql-asm-memory-growth.js` : Asm.js doesn't allow for memory to grow by default, because it is slower and de-optimizes. If you are using sql-asm.js and you see this error (`Cannot enlarge memory arrays`), use this file.
+ - `sql-asm.js` : The older asm.js version of Sql.js. Slower and larger. Provided for compatibility reasons. Includes memory-growth patch.
  - `sql-asm-debug.js` : The _Debug_ asm.js version of Sql.js. Use this for local development.
  - `worker.*` - Web Worker versions of the above libraries. More limited API. See [examples/GUI/gui.js](examples/GUI/gui.js) for a good example of this.
 

--- a/examples/requireJS.html
+++ b/examples/requireJS.html
@@ -8,7 +8,7 @@
     baseUrl: baseUrl
   });
 
-  // Options: 'sql-wasm', 'sql-asm', 'sql-asm-memory-growth.js', 'sql-wasm-debug', 'sql-asm-debug'
+  // Options: 'sql-wasm', 'sql-asm', 'sql-wasm-debug', 'sql-asm-debug'
   require(['sql-wasm'],
     function success(initSqlJs) {
       console.log(typeof initSqlJs);

--- a/package.json
+++ b/package.json
@@ -21,12 +21,11 @@
 	"scripts": {
 		"build": "make",
 		"rebuild": "make clean && make",
-		"test": "npm run lint && npm run test-asm && npm run test-asm-debug && npm run test-wasm && npm run test-wasm-debug && npm run test-asm-memory-growth",
+		"test": "npm run lint && npm run test-asm && npm run test-asm-debug && npm run test-wasm && npm run test-wasm-debug",
 		"lint": "eslint .",
 		"prettify": "eslint . --fix",
 		"test-asm": "node test/all.js asm",
 		"test-asm-debug": "node test/all.js asm-debug",
-		"test-asm-memory-growth": "node test/all.js asm-memory-growth",
 		"test-wasm": "node test/all.js wasm",
 		"test-wasm-debug": "node test/all.js wasm-debug",
 		"doc": "jsdoc -c .jsdoc.config.json"

--- a/test/test_worker.js
+++ b/test/test_worker.js
@@ -36,7 +36,7 @@ class Worker {
 exports.test = async function test(SQL, assert) {
   var target = process.argv[2];
   var file = target ? "sql-" + target : "sql-wasm";
-  if (file.indexOf('wasm') > -1 || file.indexOf('memory-growth') > -1) {
+  if (file.indexOf('wasm') > -1) {
     console.error("Skipping worker test for " + file + ". Not implemented yet");
     return;
   };


### PR DESCRIPTION
Co-authored-by: Yan Li <yanli0303@outlook.com>
Co-authored-by: kai zhu <kaizhu256@gmail.com>

this implements suggestion https://github.com/sql-js/sql.js/issues/239#issuecomment-643687061

removed or edited all references to memory-growth using command `git grep -i 'memory.*growth'`