### PR TITLE
Allow passing ModuleConfig to the worker

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -84,7 +84,7 @@ function onError(err) {
 
 if (typeof importScripts === "function") {
     db = null;
-    var sqlModuleReady = initSqlJs();
+    var sqlModuleReady = initSqlJs(self['ModuleConfig']);
     self.onmessage = function onmessage(event) {
         return sqlModuleReady
             .then(onModuleReady.bind(event))

--- a/src/worker.js
+++ b/src/worker.js
@@ -84,7 +84,7 @@ function onError(err) {
 
 if (typeof importScripts === "function") {
     db = null;
-    var sqlModuleReady = initSqlJs(self['ModuleConfig']);
+    var sqlModuleReady = initSqlJs(self["ModuleConfig"]);
     self.onmessage = function onmessage(event) {
         return sqlModuleReady
             .then(onModuleReady.bind(event))


### PR DESCRIPTION
Right now there is no way to configure locateFile when loading sql.js as a worker.  Allow defining a global ModuleConfig object to customize the worker environment.  This is particularly useful when loading from a CDN with importScripts.