### PR TITLE
Run `npm ci` automatically after the devcontainer is created.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,9 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "yarn install",
+	// We use `npm ci` instead of `npm install` because we want to respect the lockfile and ONLY the lockfile.
+	// That way, our devcontainer is more reproducible. --Taytay
+	"postCreateCommand": "npm ci",
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node"
 }


### PR DESCRIPTION
This reduces the chance that another dev will forget to do this (like I did the first time I opened it).