### PR TITLE
Upgrade to Emscripten 2.0.29

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,7 +24,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
 # Install EMSDK to /emsdk just like the EMSDK Dockerfile: https://github.com/emscripten-core/emsdk/blob/master/docker/Dockerfile
 ENV EMSDK /emsdk
 # We pin EMSDK to 2.0.15 rather than 'latest' so that everyone is using the same compiler version
-ENV EMSCRIPTEN_VERSION 2.0.15
+ENV EMSCRIPTEN_VERSION 2.0.29
 
 RUN git clone https://github.com/emscripten-core/emsdk.git $EMSDK
 
@@ -36,7 +36,7 @@ RUN echo "## Install Emscripten" \
 # Copied directly from https://github.com/emscripten-core/emsdk/blob/master/docker/Dockerfile
 RUN cd ${EMSDK} \
     && echo "## Generate standard configuration" \
-    && ./emsdk activate $EMSCRIPTEN_VERSION \
+    && ./emsdk activate ${EMSCRIPTEN_VERSION} \
     && chmod 777 ${EMSDK}/upstream/emscripten \
     && chmod -R 777 ${EMSDK}/upstream/emscripten/cache \
     && echo "int main() { return 0; }" > hello.c \
@@ -47,6 +47,7 @@ RUN cd ${EMSDK} \
 ENV PATH $EMSDK:$EMSDK/upstream/emscripten/:$PATH
 
 # Cleanup Emscripten installation and strip some symbols
+# Copied directly from https://github.com/emscripten-core/emsdk/blob/master/docker/Dockerfile
 RUN echo "## Aggressive optimization: Remove debug symbols" \
     && cd ${EMSDK} && . ./emsdk_env.sh \
     # Remove debugging symbols from embedded node (extra 7MB)
@@ -60,6 +61,12 @@ RUN echo "## Aggressive optimization: Remove debug symbols" \
     && echo "## Done"
 
 RUN echo ". /emsdk/emsdk_env.sh" >> /etc/bash.bashrc
+# We must set the EM_NODE_JS environment variable for a somewhat silly reason
+# We run our build scripts with `npm run`, which sets the NODE environment variable as it runs.
+# The EMSDK picks up on that environment variable and gives a deprecation warning: warning: honoring legacy environment variable `NODE`.  Please switch to using `EM_NODE_JS` instead`
+# So, we are going to put this environment variable here explicitly to avoid the deprecation warning.
+RUN echo 'export EM_NODE_JS="$EMSDK_NODE"' >> /etc/bash.bashrc
+
 # END EMSDK
 # --------------------------------------------------------------------
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,9 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "yarn install",
+	// We use `npm ci` instead of `npm install` because we want to respect the lockfile and ONLY the lockfile.
+	// That way, our devcontainer is more reproducible. --Taytay
+	"postCreateCommand": "npm ci",
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node"
 }

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ EMFLAGS = \
 	-s RESERVED_FUNCTION_POINTERS=64 \
 	-s ALLOW_TABLE_GROWTH=1 \
 	-s EXPORTED_FUNCTIONS=@src/exported_functions.json \
-	-s EXTRA_EXPORTED_RUNTIME_METHODS=@src/exported_runtime_methods.json \
+	-s EXPORTED_RUNTIME_METHODS=@src/exported_runtime_methods.json \
 	-s SINGLE_FILE=0 \
 	-s NODEJS_CATCH_EXIT=0 \
 	-s NODEJS_CATCH_REJECTION=0
@@ -154,7 +154,7 @@ out/sqlite3.bc: sqlite-src/$(SQLITE_AMALGAMATION)
 out/extension-functions.bc: sqlite-src/$(SQLITE_AMALGAMATION)
 	mkdir -p out
 	# Generate llvm bitcode
-	$(EMCC) $(CFLAGS) -s LINKABLE=1 -c sqlite-src/$(SQLITE_AMALGAMATION)/extension-functions.c -o $@
+	$(EMCC) $(CFLAGS) -c sqlite-src/$(SQLITE_AMALGAMATION)/extension-functions.c -o $@
 
 # TODO: This target appears to be unused. If we re-instatate it, we'll need to add more files inside of the JS folder
 # module.tar.gz: test package.json AUTHORS README.md dist/sql-asm.js


### PR DESCRIPTION
I am not sure if this is a good idea to periodically do this or not, but it did expose a couple of surprising compile-time warnings that took me a while to work out, so I think there is value in it.

Note that I built this on top of my work in my other PR #476, so that `npm ci` commit will disappear from this diff when that's merged. (I rarely work on open source projects, so I'm not sure the best way to more easily capture stacking PRs like this when the branch I'm stacking on top of doesn't exist in the target repo).

It's worth noting that the compiled files appear to be smaller. (Emscripted 2.0.29 on the left. Latest release of sql.js on the right).
![image](https://user-images.githubusercontent.com/1330693/131265006-801150cd-5422-4c6f-8b87-80ff9aa597e7.png)

The only testing I've done is the `npm test`. I don't know if we need a more in-depth test suite and/or a performance test suite for these sorts of changes.