### PR TITLE
Allow hooking into the filesystem and providing a persistent backend (like absurd-sql)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ EMFLAGS_DEBUG = \
 	-s ASSERTIONS=1 \
 	-O1
 
-BITCODE_FILES = out/sqlite3.bc out/extension-functions.bc
+BITCODE_FILES = out/sqlite3.bc out/extension-functions.bc out/vfs.bc
 
 OUTPUT_WRAPPER_FILES = src/shell-pre.js src/shell-post.js
 
@@ -79,13 +79,13 @@ all: optimized debug worker
 debug: dist/sql-asm-debug.js dist/sql-wasm-debug.js
 
 dist/sql-asm-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
-	$(EMCC) $(EMFLAGS) $(EMFLAGS_DEBUG) $(EMFLAGS_ASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
+	EMCC_CLOSURE_ARGS="--externs src/fs-externs.js" $(EMCC) $(EMFLAGS) $(EMFLAGS_DEBUG) $(EMFLAGS_ASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
 	mv $@ out/tmp-raw.js
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
 	rm out/tmp-raw.js
 
 dist/sql-wasm-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
-	$(EMCC) $(EMFLAGS) $(EMFLAGS_DEBUG) $(EMFLAGS_WASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
+	EMCC_CLOSURE_ARGS="--externs src/fs-externs.js" $(EMCC) $(EMFLAGS) $(EMFLAGS_DEBUG) $(EMFLAGS_WASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
 	mv $@ out/tmp-raw.js
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
 	rm out/tmp-raw.js
@@ -94,19 +94,19 @@ dist/sql-wasm-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FI
 optimized: dist/sql-asm.js dist/sql-wasm.js dist/sql-asm-memory-growth.js
 
 dist/sql-asm.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
-	$(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_ASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
+	EMCC_CLOSURE_ARGS="--externs src/fs-externs.js" $(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_ASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
 	mv $@ out/tmp-raw.js
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
 	rm out/tmp-raw.js
 
 dist/sql-wasm.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
-	$(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_WASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
+	EMCC_CLOSURE_ARGS="--externs src/fs-externs.js" $(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_WASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
 	mv $@ out/tmp-raw.js
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
 	rm out/tmp-raw.js
 
 dist/sql-asm-memory-growth.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
-	$(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_ASM_MEMORY_GROWTH) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
+	EMCC_CLOSURE_ARGS="--externs src/fs-externs.js" $(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_ASM_MEMORY_GROWTH) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
 	mv $@ out/tmp-raw.js
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
 	rm out/tmp-raw.js
@@ -155,6 +155,11 @@ out/extension-functions.bc: sqlite-src/$(SQLITE_AMALGAMATION)
 	mkdir -p out
 	# Generate llvm bitcode
 	$(EMCC) $(CFLAGS) -c sqlite-src/$(SQLITE_AMALGAMATION)/extension-functions.c -o $@
+
+out/vfs.bc: src/vfs.c sqlite-src/$(SQLITE_AMALGAMATION)
+	mkdir -p out
+	# Generate llvm bitcode
+	$(EMCC) $(CFLAGS) -s LINKABLE=1 -I sqlite-src/$(SQLITE_AMALGAMATION) -c src/vfs.c -o $@
 
 # TODO: This target appears to be unused. If we re-instatate it, we'll need to add more files inside of the JS folder
 # module.tar.gz: test package.json AUTHORS README.md dist/sql-asm.js

--- a/Makefile
+++ b/Makefile
@@ -73,19 +73,21 @@ EMFLAGS_PRE_JS_FILES = \
 
 EXPORTED_METHODS_JSON_FILES = src/exported_functions.json src/exported_runtime_methods.json
 
+FS_EXTERN_PATH = "$(realpath -s ./src/fs-externs.js)"
+
 all: optimized debug worker
 
 .PHONY: debug
 debug: dist/sql-asm-debug.js dist/sql-wasm-debug.js
 
 dist/sql-asm-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
-	EMCC_CLOSURE_ARGS="--externs src/fs-externs.js" $(EMCC) $(EMFLAGS) $(EMFLAGS_DEBUG) $(EMFLAGS_ASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
+	EMCC_CLOSURE_ARGS="--externs ${FS_EXTERN_PATH}" $(EMCC) $(EMFLAGS) $(EMFLAGS_DEBUG) $(EMFLAGS_ASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
 	mv $@ out/tmp-raw.js
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
 	rm out/tmp-raw.js
 
 dist/sql-wasm-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
-	EMCC_CLOSURE_ARGS="--externs src/fs-externs.js" $(EMCC) $(EMFLAGS) $(EMFLAGS_DEBUG) $(EMFLAGS_WASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
+	EMCC_CLOSURE_ARGS="--externs ${FS_EXTERN_PATH}" $(EMCC) $(EMFLAGS) $(EMFLAGS_DEBUG) $(EMFLAGS_WASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
 	mv $@ out/tmp-raw.js
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
 	rm out/tmp-raw.js
@@ -94,19 +96,19 @@ dist/sql-wasm-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FI
 optimized: dist/sql-asm.js dist/sql-wasm.js dist/sql-asm-memory-growth.js
 
 dist/sql-asm.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
-	EMCC_CLOSURE_ARGS="--externs src/fs-externs.js" $(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_ASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
+	EMCC_CLOSURE_ARGS="--externs ${FS_EXTERN_PATH}" $(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_ASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
 	mv $@ out/tmp-raw.js
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
 	rm out/tmp-raw.js
 
 dist/sql-wasm.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
-	EMCC_CLOSURE_ARGS="--externs src/fs-externs.js" $(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_WASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
+	EMCC_CLOSURE_ARGS="--externs ${FS_EXTERN_PATH}" $(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_WASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
 	mv $@ out/tmp-raw.js
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
 	rm out/tmp-raw.js
 
 dist/sql-asm-memory-growth.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
-	EMCC_CLOSURE_ARGS="--externs src/fs-externs.js" $(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_ASM_MEMORY_GROWTH) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
+	EMCC_CLOSURE_ARGS="--externs ${FS_EXTERN_PATH}" $(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_ASM_MEMORY_GROWTH) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
 	mv $@ out/tmp-raw.js
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
 	rm out/tmp-raw.js

--- a/src/api.js
+++ b/src/api.js
@@ -818,6 +818,7 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
     function Database(data, { filename = false } = {}) {
         if(filename === false) {
           this.filename = "dbfile_" + (0xffffffff * Math.random() >>> 0);
+          this.memoryFile = true;
           if (data != null) {
             FS.createDataFile("/", this.filename, data, true, true);
           }
@@ -1109,7 +1110,10 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
         Object.values(this.functions).forEach(removeFunction);
         this.functions = {};
         this.handleError(sqlite3_close_v2(this.db));
-        FS.unlink("/" + this.filename);
+
+        if(this.memoryFile) {
+          FS.unlink("/" + this.filename);
+        }
         this.db = null;
     };
 

--- a/src/api.js
+++ b/src/api.js
@@ -811,13 +811,19 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
     * @memberof module:SqlJs
     * Open a new database either by creating a new one or opening an existing
     * one stored in the byte array passed in first argument
-    * @param {number[]} data An array of bytes representing
-    * an SQLite database file
+    * @param {number[]|string} data An array of bytes representing
+    * an SQLite database file or a path
+    * @param {Object} opts Options to specify a filename
     */
-    function Database(data) {
-        this.filename = "dbfile_" + (0xffffffff * Math.random() >>> 0);
-        if (data != null) {
+    function Database(data, { filename = false } = {}) {
+        if(filename === false) {
+          this.filename = "dbfile_" + (0xffffffff * Math.random() >>> 0);
+          if (data != null) {
             FS.createDataFile("/", this.filename, data, true, true);
+          }
+        }
+        else {
+          this.filename = data;
         }
         this.handleError(sqlite3_open(this.filename, apiTemp));
         this.db = getValue(apiTemp, "i32");
@@ -1231,4 +1237,44 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
 
     // export Database to Module
     Module.Database = Database;
+
+    // Because emscripten doesn't allow us to handle `ioctl`, we need
+    // to manually install lock/unlock methods. Unfortunately we need
+    // to keep track of a mapping of `sqlite_file*` pointers to filename
+    // so that we can tell our filesystem which files to lock/unlock
+    var sqliteFiles = new Map();
+
+    Module["register_for_idb"] = (customFS) => {
+      var SQLITE_BUSY = 5;
+
+      function open(namePtr, file) {
+        var path = UTF8ToString(namePtr);
+        sqliteFiles.set(file, path);
+      }
+
+      function lock(file, lockType) {
+        var path = sqliteFiles.get(file);
+        var success = customFS.lock(path, lockType)
+        return success? 0 : SQLITE_BUSY;
+      }
+
+      function unlock(file,lockType) {
+        var path = sqliteFiles.get(file);
+        customFS.unlock(path, lockType)
+        return 0;
+      }
+
+      let lockPtr = addFunction(lock, 'iii');
+      let unlockPtr = addFunction(unlock, 'iii');
+      let openPtr = addFunction(open, 'vii');
+      Module["_register_for_idb"](lockPtr, unlockPtr, openPtr)
+    }
+
+    // TODO: This isn't called from anywhere yet. We need to
+    // somehow cleanup closed files from `sqliteFiles`
+    Module["cleanup_file"] = (path) => {
+      let filesInfo = [...sqliteFiles.entries()]
+      let fileInfo = filesInfo.find(f => f[1] === path);
+      sqliteFiles.delete(fileInfo[0])
+    }
 };

--- a/src/api.js
+++ b/src/api.js
@@ -1277,4 +1277,9 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
       let fileInfo = filesInfo.find(f => f[1] === path);
       sqliteFiles.delete(fileInfo[0])
     }
+
+    Module["reset_filesystem"] = () => {
+      FS.root = null;
+      FS.staticInit();
+    }
 };

--- a/src/exported_functions.json
+++ b/src/exported_functions.json
@@ -41,5 +41,7 @@
 "_sqlite3_result_int",
 "_sqlite3_result_int64",
 "_sqlite3_result_error",
+"_sqlite3_vfs_find",
+"_register_for_idb",
 "_RegisterExtensionFunctions"
 ]

--- a/src/exported_runtime_methods.json
+++ b/src/exported_runtime_methods.json
@@ -3,5 +3,6 @@
 "stackAlloc",
 "stackSave",
 "stackRestore",
-"UTF8ToString"
+"UTF8ToString",
+"FS"
 ]

--- a/src/fs-externs.js
+++ b/src/fs-externs.js
@@ -1,0 +1,48 @@
+/**
+ * @externs
+ */
+
+Module.FS = class {
+  constructor() {
+    this.ErrnoError = class {};
+  }
+  mount() {}
+  isRoot() {}
+  isFile() {}
+  isDir() {}
+  stat() {}
+  /** @return {FSNode} */
+  lookupPath() {}
+  /** @return {FSNode} */
+  lookupNode() {}
+  /** @return {FSNode} */
+  createNode() {}
+  /** @return {FSNode} */
+  mknod() {}
+};
+
+Module.FS.FSNode = class {
+  constructor() {
+    this.node_ops = {
+      getattr: () => {},
+      setattr: () => {},
+      lookup: () => {},
+      mknod: () => {},
+      rename: () => {},
+      unlink: () => {},
+      rmdir: () => {},
+      reaaddir: () => {},
+      symlink: () => {},
+      readlink: () => {}
+    };
+
+    this.stream_ops = {
+      llseek: () => {},
+      read: () => {},
+      write: () => {},
+      allocate: () => {},
+      mmap: () => {},
+      msync: () => {}
+    };
+  }
+};

--- a/src/fs-externs.js
+++ b/src/fs-externs.js
@@ -5,10 +5,8 @@
 Module.FS = class {
   constructor() {
     this.ErrnoError = class {};
-    this.filesystems = {}
   }
   mount() {}
-  unmount() {}
   isRoot() {}
   isFile() {}
   isDir() {}

--- a/src/fs-externs.js
+++ b/src/fs-externs.js
@@ -5,8 +5,10 @@
 Module.FS = class {
   constructor() {
     this.ErrnoError = class {};
+    this.filesystems = {}
   }
   mount() {}
+  unmount() {}
   isRoot() {}
   isFile() {}
   isDir() {}

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -1,0 +1,49 @@
+#include <sqlite3.h>
+#include <stdio.h>
+
+static int (*defaultOpen)(sqlite3_vfs *vfs, const char *zName, sqlite3_file *file, int flags, int *pOutFlags);
+
+static void (*fsOpen)(const char *, void*);
+static int (*fsLock)(sqlite3_file *file, int);
+static int (*fsUnlock)(sqlite3_file *file, int);
+
+static int blockDeviceCharacteristics(sqlite3_file* file) {
+    return SQLITE_IOCAP_SAFE_APPEND |
+        SQLITE_IOCAP_SEQUENTIAL |
+        SQLITE_IOCAP_UNDELETABLE_WHEN_OPEN;
+}
+
+static int block_lock(sqlite3_file *file, int lock) {
+    return fsLock(file, lock);
+}
+
+static int block_unlock(sqlite3_file *file, int lock) {
+    return fsUnlock(file, lock);
+}
+
+static int block_open(sqlite3_vfs *vfs, const char *zName, sqlite3_file *file, int flags, int *pOutFlags) {
+    int res = defaultOpen(vfs, zName, file, flags, pOutFlags);
+
+    printf("Opened!\n");
+
+    sqlite3_io_methods* methods = (sqlite3_io_methods*)file->pMethods;
+    methods->xDeviceCharacteristics = blockDeviceCharacteristics;
+    methods->xLock = block_lock;
+    methods->xUnlock = block_unlock;
+
+    fsOpen(zName, (void*)file);
+
+    return res;
+}
+
+void register_for_idb(int(*lockFile)(sqlite3_file*,int), int(*unlockFile)(sqlite3_file*,int), void(*openFile)(const char*, void*)) {
+    sqlite3_vfs *vfs = sqlite3_vfs_find("unix");
+    defaultOpen = vfs->xOpen;
+
+    vfs->xOpen = block_open;
+    sqlite3_vfs_register(vfs, 1);
+
+    fsLock = lockFile;
+    fsUnlock = unlockFile;
+    fsOpen = openFile;
+}

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -24,8 +24,6 @@ static int block_unlock(sqlite3_file *file, int lock) {
 static int block_open(sqlite3_vfs *vfs, const char *zName, sqlite3_file *file, int flags, int *pOutFlags) {
     int res = defaultOpen(vfs, zName, file, flags, pOutFlags);
 
-    printf("Opened!\n");
-
     sqlite3_io_methods* methods = (sqlite3_io_methods*)file->pMethods;
     methods->xDeviceCharacteristics = blockDeviceCharacteristics;
     methods->xLock = block_lock;


### PR DESCRIPTION
This is (finally) a follow-up to my [absurd-sql](https://github.com/jlongster/absurd-sql) project I talked about here: https://github.com/sql-js/sql.js/issues/447#issuecomment-897326740

These are the changes so far required to make it work. It's not a lot of changes, but there are several small things:

* We need to stabilize the FS exports to projects can hook into the filesystem. Long-term, I'd like to figure out a better way to do this. Emscripten has plans to change their FS implementation a lot, so it will likely change. For now, this lets us hook in the FS that's already there. We do that by specifying some exports so closure doesn't minify them.
* We add a `filename` to the `Database` constructor which is a boolean specifying that you've passed in a filename, not a buffer. Open to a better API here.
* Don't delete the DB on close (if it's not a buffer), haha. If  Obviously now that it persists we don't want that.
* Perhaps the ugliest part, we add a little bit of C code to customize the default unix vfs. One reason to do this is to customize `blockDeviceCharacteristics` which might improve performance characteristics. The bigger reason is to hook into the lock/unlock methods of the vfs and override them. Unfortunately, this requires some ugly code in `api.js` to map the internal sqlite file to a filename and then call into our FS to handle them.

Normally, we could handle the `fcntl` system call at the FS layer. Unfortunately, right now emscripten doesn't provide a way to do that. If it did, we wouldn't need the last point. We might still want to override `blockDeviceCharacteristics`, but that could be an optional stop to improve performance. Right now it's critical so we get locking.

I've filed an issue with emscripten: https://github.com/emscripten-core/emscripten/issues/15070. This PR could be simplified once we have that. Not sure if you want to wait on that to land this PR or now.

Anyway, I'm open to how you want to proceed. While absurd-sql is robust and ready for production (I'm using it in prod), the API and implementation here is somewhat proof of concept. Let me know what you think.