### PR TITLE
sqlite 3.38.5

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,8 +23,8 @@ FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
 # BEGIN EMSDK 
 # Install EMSDK to /emsdk just like the EMSDK Dockerfile: https://github.com/emscripten-core/emsdk/blob/master/docker/Dockerfile
 ENV EMSDK /emsdk
-# We pin EMSDK to 2.0.15 rather than 'latest' so that everyone is using the same compiler version
-ENV EMSCRIPTEN_VERSION 2.0.29
+# We pin the EMSDK version rather than 'latest' so that everyone is using the same compiler version
+ENV EMSCRIPTEN_VERSION 3.0.0
 
 RUN git clone https://github.com/emscripten-core/emsdk.git $EMSDK
 

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@
 
 # I got this handy makefile syntax from : https://github.com/mandel59/sqlite-wasm (MIT License) Credited in LICENSE
 # To use another version of Sqlite, visit https://www.sqlite.org/download.html and copy the appropriate values here:
-SQLITE_AMALGAMATION = sqlite-amalgamation-3360000
-SQLITE_AMALGAMATION_ZIP_URL = https://www.sqlite.org/2021/sqlite-amalgamation-3360000.zip
-SQLITE_AMALGAMATION_ZIP_SHA3 = d25609210ec93b3c8c7da66a03cf82e2c9868cfbd2d7d866982861855e96f972
+SQLITE_AMALGAMATION = sqlite-amalgamation-3380500
+SQLITE_AMALGAMATION_ZIP_URL = https://www.sqlite.org/2022/sqlite-amalgamation-3380500.zip
+SQLITE_AMALGAMATION_ZIP_SHA3 = bfad5c42b767520a546251b9876e4a4b127fb651c437b968b149070e09252807
 
 # Note that extension-functions.c hasn't been updated since 2010-02-06, so likely doesn't need to be updated
 EXTENSION_FUNCTIONS = extension-functions.c


### PR DESCRIPTION
* Upgrade sqlite to 3.38.5
* Upgrade Emscripten to 3.0.0

Seems to work well for me. All tests except `test_worker` passed, but that test didn't work for me before the upgrade.

Had some issues with compilation where it would fail (signal -9) the first time. Probably something wrong with the VS Code devcontainer setup. Build went through on second attempt.