### PR TITLE
Enable custom aggregate functions (take 2)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     ignorePatterns: [
         "/dist/",
         "/examples/",
+        "/documentation/",
         "/node_modules/",
         "/out/",
         "/src/shell-post.js",

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ db.run("INSERT INTO hello VALUES (add_js(7, 3), add_js('Hello ', 'world'));"); /
 // You can create custom aggregation functions, by passing a name
 // and a set of functions to `db.create_aggregate`:
 //
-// - a initialization function. This function receives no arguments and returns
+// - an initialization function. This function receives no arguments and returns
 //   the initial value for the aggregation function
 // - a step function. This function receives as a first argument the state
 //   object created in init, as well as the values received in the step. It

--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ db.create_aggregate(
   }
 );
 
-```suggestion
 db.exec("SELECT json_agg(column1) FROM (VALUES ('hello'), ('world'))");
 // -> The result of the query is the string '["hello","world"]'
 

--- a/README.md
+++ b/README.md
@@ -75,37 +75,25 @@ db.create_function("add_js", add);
 // Run a query in which the function is used
 db.run("INSERT INTO hello VALUES (add_js(7, 3), add_js('Hello ', 'world'));"); // Inserts 10 and 'Hello world'
 
-// You can create aggregation functions, by passing a name and three functions
-// to `db.create_aggregate`:
+// You can create custom aggregation functions, by passing a name, an initial
+// value, and two functions to `db.create_aggregate`:
 //
-// - an init function. This function receives no arguments and will be called
-//   when the aggregate begins. Returns a state object that will be passed to the
-//   other two functions if you need to track state.
 // - a step function. This function receives as a first argument the state
 //   object created in init, as well as the values received in the step. It
-//   will be called on every value to be aggregated. Does not return anything.
+//   will be called on every value to be aggregated, and its return value
+//   will be used as the state for the next iteration.
 // - a finalizer. This function receives one argument, the state object, and
-//   returns the final value of the aggregate
+//   returns the final value of the aggregate. It can be omitted, in which case
+//   the value of the `state` variable will be used.
 //
 // Here is an example aggregation function, `json_agg`, which will collect all
 // input values and return them as a JSON array:
 db.create_aggregate(
   "json_agg",
-  function() {
-    // This is the init function, which returns a state object:
-    return {
-      values: []
-    };
-  },
-  function(state, val) {
-    // This is the step function, which will store each value it receives in
-    // the values array of the state object
-    state.values.push(val);
-  },
-  function(state) {
-    // This is the finalize function, which converts the received values from
-    // the state object into a JSON array and returns that
-    return JSON.stringify(state.values);
+  [],
+  {
+    step: (state, val) => state.push(val),
+    finalize: (state) => JSON.stringify(state),
   }
 );
 

--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ db.create_aggregate(
   }
 );
 
-// Now if you run this query:
-var result = db.exec("SELECT json_agg(somecol) FROM atable;");
-console.log("You'll get a json-encoded list of values: ", result[0].values[0])
+```suggestion
+db.exec("SELECT json_agg(column1) FROM (VALUES ('hello'), ('world'))");
+// -> The result of the query is the string '["hello","world"]'
 
 // Export the database to an Uint8Array containing the SQLite database file
 const binaryArray = db.export();

--- a/README.md
+++ b/README.md
@@ -101,8 +101,7 @@ db.create_aggregate(
 
 // Now if you run this query:
 var result = db.exec("SELECT json_agg(somecol) FROM atable;");
-
-// result will be a json-encoded string representing each value of `somecol` in `atable`.
+console.log("You'll get a json-encoded list of values: ", result[0].values[0])
 
 // Export the database to an Uint8Array containing the SQLite database file
 const binaryArray = db.export();

--- a/README.md
+++ b/README.md
@@ -78,15 +78,15 @@ db.run("INSERT INTO hello VALUES (add_js(7, 3), add_js('Hello ', 'world'));"); /
 // You can create custom aggregation functions, by passing a name
 // and a set of functions to `db.create_aggregate`:
 //
-// - an initialization function. This function receives no argument and returns
-//   the initial value for the aggregation function
-// - a step function. This function receives as a first argument the state
-//   object created in init, as well as the values received in the step. It
-//   will be called on every value to be aggregated, and its return value
-//   will be used as the state for the next iteration.
-// - a finalizer. This function receives one argument, the state object, and
+// - an `init` function. This function receives no argument and returns
+//   the initial value for the state of the aggregate function.
+// - a `step` function. This function takes two arguments
+//    - the current state of the aggregation
+//    - a new value to aggregate to the state
+//  It should return a new value for the state.
+// - a `finalize` function. This function receives a state object, and
 //   returns the final value of the aggregate. It can be omitted, in which case
-//   the value of the `state` variable will be used.
+//   the final value of the state will be returned directly by the aggregate function.
 //
 // Here is an example aggregation function, `json_agg`, which will collect all
 // input values and return them as a JSON array:

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ db.run("INSERT INTO hello VALUES (add_js(7, 3), add_js('Hello ', 'world'));"); /
 // You can create custom aggregation functions, by passing a name
 // and a set of functions to `db.create_aggregate`:
 //
-// - an initialization function. This function receives no arguments and returns
+// - an initialization function. This function receives no argument and returns
 //   the initial value for the aggregation function
 // - a step function. This function receives as a first argument the state
 //   object created in init, as well as the values received in the step. It

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ db.create_aggregate(
   "json_agg",
   {
     init: () => [],
-    step: (state, val) => state.push(val),
+    step: (state, val) => [...state, val],
     finalize: (state) => JSON.stringify(state),
   }
 );

--- a/README.md
+++ b/README.md
@@ -75,9 +75,11 @@ db.create_function("add_js", add);
 // Run a query in which the function is used
 db.run("INSERT INTO hello VALUES (add_js(7, 3), add_js('Hello ', 'world'));"); // Inserts 10 and 'Hello world'
 
-// You can create custom aggregation functions, by passing a name, an initial
-// value, and two functions to `db.create_aggregate`:
+// You can create custom aggregation functions, by passing a name
+// and a set of functions to `db.create_aggregate`:
 //
+// - a initialization function. This function receives no arguments and returns
+//   the initial value for the aggregation function
 // - a step function. This function receives as a first argument the state
 //   object created in init, as well as the values received in the step. It
 //   will be called on every value to be aggregated, and its return value
@@ -90,8 +92,8 @@ db.run("INSERT INTO hello VALUES (add_js(7, 3), add_js('Hello ', 'world'));"); /
 // input values and return them as a JSON array:
 db.create_aggregate(
   "json_agg",
-  [],
   {
+    init: () => [],
     step: (state, val) => state.push(val),
     finalize: (state) => JSON.stringify(state),
   }

--- a/README.md
+++ b/README.md
@@ -75,6 +75,45 @@ db.create_function("add_js", add);
 // Run a query in which the function is used
 db.run("INSERT INTO hello VALUES (add_js(7, 3), add_js('Hello ', 'world'));"); // Inserts 10 and 'Hello world'
 
+// You can create aggregation functions, by passing a name and three functions
+// to `db.create_aggregate`:
+//
+// - an init function. This function receives no arguments and will be called
+//   when the aggregate begins. Returns a state object that will be passed to the
+//   other two functions if you need to track state.
+// - a step function. This function receives as a first argument the state
+//   object created in init, as well as the values received in the step. It
+//   will be called on every value to be aggregated. Does not return anything.
+// - a finalizer. This function receives one argument, the state object, and
+//   returns the final value of the aggregate
+//
+// Here is an example aggregation function, `json_agg`, which will collect all
+// input values and return them as a JSON array:
+db.create_aggregate(
+  "json_agg",
+  function() {
+    // This is the init function, which returns a state object:
+    return {
+      values: []
+    };
+  },
+  function(state, val) {
+    // This is the step function, which will store each value it receives in
+    // the values array of the state object
+    state.values.push(val);
+  },
+  function(state) {
+    // This is the finalize function, which converts the received values from
+    // the state object into a JSON array and returns that
+    return JSON.stringify(state.values);
+  }
+);
+
+// Now if you run this query:
+var result = db.exec("SELECT json_agg(somecol) FROM atable;");
+
+// result will be a json-encoded string representing each value of `somecol` in `atable`.
+
 // Export the database to an Uint8Array containing the SQLite database file
 const binaryArray = db.export();
 ```

--- a/src/api.js
+++ b/src/api.js
@@ -1271,9 +1271,13 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
             throw "An aggregate function must have a step function";
         }
 
-        aggregateFunctions["init"] = aggregateFunctions["init"] || (() => null);
+        // Default initializer and finalizer
+        function init() { return null; }
+        function finalize(state) { return state; }
+
+        aggregateFunctions["init"] = aggregateFunctions["init"] || init;
         aggregateFunctions["finalize"] = aggregateFunctions["finalize"]
-            || ((state) => state);
+            || finalize;
 
         // state is a state object; we'll use the pointer p to serve as the
         // key for where we hold our state so that multiple invocations of

--- a/src/api.js
+++ b/src/api.js
@@ -1176,7 +1176,7 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
                 if (result === null) {
                     sqlite3_result_null(cx);
                 } else if (result.length != null) {
-                    var blobptr = allocate(result, "i8", ALLOC_NORMAL);
+                    var blobptr = allocate(result, ALLOC_NORMAL);
                     sqlite3_result_blob(cx, blobptr, result.length, -1);
                     _free(blobptr);
                 } else {

--- a/src/api.js
+++ b/src/api.js
@@ -1321,7 +1321,6 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
             } catch (error) {
                 delete state[p];
                 sqlite3_result_error(cx, error, -1);
-                state = null;
                 return;
             }
 

--- a/src/api.js
+++ b/src/api.js
@@ -1131,81 +1131,90 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
         return sqlite3_changes(this.db);
     };
 
-    /** Register a custom function with SQLite
-    @example Register a simple function
-        db.create_function("addOne", function (x) {return x+1;})
-        db.exec("SELECT addOne(1)") // = 2
+    var extract_blob = function extract_blob(ptr) {
+        var size = sqlite3_value_bytes(ptr);
+        var blob_ptr = sqlite3_value_blob(ptr);
+        var blob_arg = new Uint8Array(size);
+        for (var j = 0; j < size; j += 1) {
+            blob_arg[j] = HEAP8[blob_ptr + j];
+        }
+        return blob_arg;
+    };
 
-    @param {string} name the name of the function as referenced in
-    SQL statements.
-    @param {function} func the actual function to be executed.
-    @return {Database} The database object. Useful for method chaining
-     */
+    var parseFunctionArguments = function parseFunctionArguments(argc, argv) {
+        var args = [];
+        for (var i = 0; i < argc; i += 1) {
+            var value_ptr = getValue(argv + (4 * i), "i32");
+            var value_type = sqlite3_value_type(value_ptr);
+            var arg;
+            if (
+                value_type === SQLITE_INTEGER
+                || value_type === SQLITE_FLOAT
+            ) {
+                arg = sqlite3_value_double(value_ptr);
+            } else if (value_type === SQLITE_TEXT) {
+                arg = sqlite3_value_text(value_ptr);
+            } else if (value_type === SQLITE_BLOB) {
+                arg = extract_blob(value_ptr);
+            } else arg = null;
+            args.push(arg);
+        }
+        return args;
+    };
+    var setFunctionResult = function setFunctionResult(cx, result) {
+        switch (typeof result) {
+            case "boolean":
+                sqlite3_result_int(cx, result ? 1 : 0);
+                break;
+            case "number":
+                sqlite3_result_double(cx, result);
+                break;
+            case "string":
+                sqlite3_result_text(cx, result, -1, -1);
+                break;
+            case "object":
+                if (result === null) {
+                    sqlite3_result_null(cx);
+                } else if (result.length != null) {
+                    var blobptr = allocate(result, "i8", ALLOC_NORMAL);
+                    sqlite3_result_blob(cx, blobptr, result.length, -1);
+                    _free(blobptr);
+                } else {
+                    sqlite3_result_error(cx, (
+                        "Wrong API use : tried to return a value "
+                        + "of an unknown type (" + result + ")."
+                    ), -1);
+                }
+                break;
+            default:
+                sqlite3_result_null(cx);
+        }
+    };
+
+    /** Register a custom function with SQLite
+      @example Register a simple function
+          db.create_function("addOne", function (x) {return x+1;})
+          db.exec("SELECT addOne(1)") // = 2
+
+      @param {string} name the name of the function as referenced in
+      SQL statements.
+      @param {function} func the actual function to be executed.
+      @return {Database} The database object. Useful for method chaining
+       */
     Database.prototype["create_function"] = function create_function(
         name,
         func
     ) {
         function wrapped_func(cx, argc, argv) {
+            var args = parseFunctionArguments(argc, argv);
             var result;
-            function extract_blob(ptr) {
-                var size = sqlite3_value_bytes(ptr);
-                var blob_ptr = sqlite3_value_blob(ptr);
-                var blob_arg = new Uint8Array(size);
-                for (var j = 0; j < size; j += 1) {
-                    blob_arg[j] = HEAP8[blob_ptr + j];
-                }
-                return blob_arg;
-            }
-            var args = [];
-            for (var i = 0; i < argc; i += 1) {
-                var value_ptr = getValue(argv + (4 * i), "i32");
-                var value_type = sqlite3_value_type(value_ptr);
-                var arg;
-                if (
-                    value_type === SQLITE_INTEGER
-                    || value_type === SQLITE_FLOAT
-                ) {
-                    arg = sqlite3_value_double(value_ptr);
-                } else if (value_type === SQLITE_TEXT) {
-                    arg = sqlite3_value_text(value_ptr);
-                } else if (value_type === SQLITE_BLOB) {
-                    arg = extract_blob(value_ptr);
-                } else arg = null;
-                args.push(arg);
-            }
             try {
                 result = func.apply(null, args);
             } catch (error) {
                 sqlite3_result_error(cx, error, -1);
                 return;
             }
-            switch (typeof result) {
-                case "boolean":
-                    sqlite3_result_int(cx, result ? 1 : 0);
-                    break;
-                case "number":
-                    sqlite3_result_double(cx, result);
-                    break;
-                case "string":
-                    sqlite3_result_text(cx, result, -1, -1);
-                    break;
-                case "object":
-                    if (result === null) {
-                        sqlite3_result_null(cx);
-                    } else if (result.length != null) {
-                        var blobptr = allocate(result, ALLOC_NORMAL);
-                        sqlite3_result_blob(cx, blobptr, result.length, -1);
-                        _free(blobptr);
-                    } else {
-                        sqlite3_result_error(cx, (
-                            "Wrong API use : tried to return a value "
-                            + "of an unknown type (" + result + ")."
-                        ), -1);
-                    }
-                    break;
-                default:
-                    sqlite3_result_null(cx);
-            }
+            setFunctionResult(cx, result);
         }
         if (Object.prototype.hasOwnProperty.call(this.functions, name)) {
             removeFunction(this.functions[name]);
@@ -1224,6 +1233,89 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
             func_ptr,
             0,
             0,
+            0
+        ));
+        return this;
+    };
+
+    /** Register a custom aggregate with SQLite
+      @example Register a aggregate function
+        db.create_aggregate(
+            "js_sum",
+            function () { return { sum: 0 }; },
+            function (state, value) { state.sum+=value; },
+            function (state) { return state.sum; }
+        );
+        db.exec("CREATE TABLE test (col); INSERT INTO test VALUES (1), (2)");
+        db.exec("SELECT js_sum(col) FROM test"); // = 3
+
+      @param {string} name the name of the aggregate as referenced in
+      SQL statements.
+      @param {function} init the actual function to be executed on initialize.
+      @param {function} step the actual function to be executed on step by step.
+      @param {function} finalize the actual function to be executed on finalize.
+      @return {Database} The database object. Useful for method chaining
+       */
+    Database.prototype["create_aggregate"] = function create_aggregate(
+        name,
+        init,
+        step,
+        finalize
+    ) {
+        var state;
+        function wrapped_step(cx, argc, argv) {
+            if (!state) {
+                state = init();
+            }
+            var args = parseFunctionArguments(argc, argv);
+            var mergedArgs = [state].concat(args);
+            try {
+                step.apply(null, mergedArgs);
+            } catch (error) {
+                sqlite3_result_error(cx, error, -1);
+            }
+        }
+        function wrapped_finalize(cx) {
+            var result;
+            try {
+                result = finalize.apply(null, [state]);
+            } catch (error) {
+                sqlite3_result_error(cx, error, -1);
+                state = null;
+                return;
+            }
+            setFunctionResult(cx, result);
+            state = null;
+        }
+
+        if (Object.prototype.hasOwnProperty.call(this.functions, name)) {
+            removeFunction(this.functions[name]);
+            delete this.functions[name];
+        }
+        if (Object.prototype.hasOwnProperty.call(
+            this.functions,
+            name + "__finalize"
+        )) {
+            removeFunction(this.functions[name + "__finalize"]);
+            delete this.functions[name + "__finalize"];
+        }
+        // The signature of the wrapped function is :
+        // void wrapped(sqlite3_context *db, int argc, sqlite3_value **argv)
+        var step_ptr = addFunction(wrapped_step, "viii");
+        // The signature of the wrapped function is :
+        // void wrapped(sqlite3_context *db)
+        var finalize_ptr = addFunction(wrapped_finalize, "vi");
+        this.functions[name] = step_ptr;
+        this.functions[name + "__finalize"] = finalize_ptr;
+        this.handleError(sqlite3_create_function_v2(
+            this.db,
+            name,
+            step.length - 1,
+            SQLITE_UTF8,
+            0,
+            0,
+            step_ptr,
+            finalize_ptr,
             0
         ));
         return this;

--- a/src/api.js
+++ b/src/api.js
@@ -69,6 +69,7 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
     var SQLITE_FLOAT = 2;
     var SQLITE_TEXT = 3;
     var SQLITE_BLOB = 4;
+    var SQLITE_NULL = 5;
     // var - Encodings, used for registering functions.
     var SQLITE_UTF8 = 1;
     // var - cwrap function
@@ -224,6 +225,14 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
         "sqlite3_result_error",
         "",
         ["number", "string", "number"]
+    );
+
+    // https://www.sqlite.org/c3ref/aggregate_context.html
+    // void *sqlite3_aggregate_context(sqlite3_context*, int nBytes)
+    var sqlite3_aggregate_context = cwrap(
+        "sqlite3_aggregate_context",
+        "number",
+        ["number", "number"]
     );
     var registerExtensionFunctions = cwrap(
         "RegisterExtensionFunctions",
@@ -1265,6 +1274,7 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
 
         var state;
         function wrapped_step(cx, argc, argv) {
+            var p = sqlite3_aggregate_context(cx, 999);
             if (!state) {
                 state = aggregateFunctions["init"].apply(null);
             }

--- a/src/api.js
+++ b/src/api.js
@@ -1262,11 +1262,8 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
         step,
         finalize
     ) {
-        var state;
+        var state = init();
         function wrapped_step(cx, argc, argv) {
-            if (!state) {
-                state = init();
-            }
             var args = parseFunctionArguments(argc, argv);
             var mergedArgs = [state].concat(args);
             try {

--- a/src/api.js
+++ b/src/api.js
@@ -1264,6 +1264,7 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
        */
     Database.prototype["create_aggregate"] = function create_aggregate(
         name,
+        initial_value,
         aggregateFunctions
     ) {
         if (!Object.hasOwnProperty.call(aggregateFunctions, "step")
@@ -1271,11 +1272,8 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
             throw "An aggregate function must have a step function";
         }
 
-        // Default initializer and finalizer
-        function init() { return null; }
+        // Default finalizer
         function finalize(state) { return state; }
-
-        aggregateFunctions["init"] = aggregateFunctions["init"] || init;
         aggregateFunctions["finalize"] = aggregateFunctions["finalize"]
             || finalize;
 
@@ -1298,7 +1296,7 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
 
             // If this is the first invocation of wrapped_step, call `init`
             if (!state[p]) {
-                state[p] = aggregateFunctions["init"].apply(null);
+                state[p] = initial_value;
             }
 
             var args = parseFunctionArguments(argc, argv);

--- a/src/api.js
+++ b/src/api.js
@@ -1304,6 +1304,13 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
         var finalize_ptr = addFunction(wrapped_finalize, "vi");
         this.functions[name] = step_ptr;
         this.functions[name + "__finalize"] = finalize_ptr;
+
+        // passing null to the sixth parameter defines this as an aggregate
+        // function
+        //
+        // > An aggregate SQL function requires an implementation of xStep and
+        // > xFinal and NULL pointer must be passed for xFunc.
+        // - http://www.sqlite.org/c3ref/create_function.html
         this.handleError(sqlite3_create_function_v2(
             this.db,
             name,

--- a/src/api.js
+++ b/src/api.js
@@ -1268,11 +1268,12 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
     ) {
         if (!Object.hasOwnProperty.call(aggregateFunctions, "step")
         ) {
-            throw "An aggregate function must have a step property";
+            throw "An aggregate function must have a step function";
         }
 
-        aggregateFunctions["init"] ||= (() => null)
-        aggregateFunctions["finalize"] ||= ((state) => state)
+        aggregateFunctions["init"] = aggregateFunctions["init"] || (() => null);
+        aggregateFunctions["finalize"] = aggregateFunctions["finalize"]
+            || ((state) => state);
 
         // state is a state object; we'll use the pointer p to serve as the
         // key for where we hold our state so that multiple invocations of

--- a/src/exported_functions.json
+++ b/src/exported_functions.json
@@ -41,5 +41,6 @@
 "_sqlite3_result_int",
 "_sqlite3_result_int64",
 "_sqlite3_result_error",
+"_sqlite3_aggregate_context",
 "_RegisterExtensionFunctions"
 ]

--- a/test/test_aggregate_functions.js
+++ b/test/test_aggregate_functions.js
@@ -1,0 +1,17 @@
+exports.test = function (SQL, assert) {
+    var db = new SQL.Database();
+
+    db.create_aggregate(
+        "js_sum",
+        function () { return { sum: 0 }; },
+        function (state, value) { state.sum += value; },
+        function (state) { return state.sum; }
+    );
+
+    db.exec("CREATE TABLE test (col);");
+    db.exec("INSERT INTO test VALUES (1), (2), (3);");
+    var result = db.exec("SELECT js_sum(col) FROM test;");
+    assert.equal(result[0].values[0][0], 6, "Simple aggregate function.");
+
+    // TODO: Add test cases..
+}

--- a/test/test_aggregate_functions.js
+++ b/test/test_aggregate_functions.js
@@ -12,7 +12,7 @@ exports.test = function (SQL, assert) {
     );
 
     db.exec("CREATE TABLE test (col);");
-    db.exec("INSERT INTO test VALUES (1), (2), (3);");
+    db.exec("INSERT INTO test VALUES (1), (2), (3), (null);");
     var result = db.exec("SELECT sum(col) FROM test;");
     assert.equal(result[0].values[0][0], 6, "Simple aggregate function.");
 
@@ -20,8 +20,10 @@ exports.test = function (SQL, assert) {
         "percentile", {
             init: function () { return { vals: [], pctile: null }; }, // init
             step: function (state, value, pctile) {
-                state.pctile = pctile;
-                state.vals.push(value);
+                if (value && !isNaN(value)) {
+                    state.pctile = pctile;
+                    state.vals.push(value);
+                }
                 return state;
             },
             finalize: function (state) {

--- a/test/test_aggregate_functions.js
+++ b/test/test_aggregate_functions.js
@@ -53,3 +53,18 @@ function percentile(arr, p) {
     }
 };
 
+if (module == require.main) {
+    const target_file = process.argv[2];
+    const sql_loader = require('./load_sql_lib');
+    sql_loader(target_file).then((sql)=>{
+        require('test').run({
+            'test functions': function(assert, done){
+                exports.test(sql, assert, done);
+            }
+        });
+    })
+    .catch((e)=>{
+        console.error(e);
+        assert.fail(e);
+    });
+}

--- a/test/test_aggregate_functions.js
+++ b/test/test_aggregate_functions.js
@@ -6,8 +6,8 @@ exports.test = function (SQL, assert) {
     var db = new SQL.Database();
 
     db.create_aggregate(
-        "sum", {
-            step: function (state, value) { return (state || 0) + value; },
+        "sum", 0, {
+            step: function (state, value) { return state + value; },
         }
     );
 
@@ -17,10 +17,11 @@ exports.test = function (SQL, assert) {
     assert.equal(result[0].values[0][0], 6, "Simple aggregate function.");
 
     db.create_aggregate(
-        "percentile", {
-            init: function () { return { vals: [], pctile: null }; }, // init
+        "percentile", { vals: [], pctile: null },
+        {
             step: function (state, value, pctile) {
-                if (value && !isNaN(value)) {
+                var typ = typeof value;
+                if (typ == "number" || typ == "bigint") {
                     state.pctile = pctile;
                     state.vals.push(value);
                 }
@@ -35,9 +36,9 @@ exports.test = function (SQL, assert) {
     assertFloat(result[0].values[0][0], 2.6, "Aggregate function with two args");
 
     db.create_aggregate(
-        "json_agg", {
-            step: function(state, val) { state = (state || []); state.push(val); return state; },
-            finalize: function(state) { return JSON.stringify(state); }
+        "json_agg", [], {
+            step: (state, val) => [...state, val],
+            finalize: (state) => JSON.stringify(state),
         }
     );
 

--- a/test/test_aggregate_functions.js
+++ b/test/test_aggregate_functions.js
@@ -1,11 +1,13 @@
 exports.test = function (SQL, assert) {
+    function assertFloat(got, expected, message="", sigma=0.001) {
+        assert.ok(got > expected - sigma && got < expected + sigma, message);
+    }
+
     var db = new SQL.Database();
 
     db.create_aggregate(
         "sum", {
-            init: function () { return { sum: 0 }; },
-            step: function (state, value) { state.sum += value; },
-            finalize: function (state) { return state.sum; }
+            step: function (state, value) { return (state || 0) + value; },
         }
     );
 
@@ -18,28 +20,32 @@ exports.test = function (SQL, assert) {
         "percentile", {
             init: function () { return { vals: [], pctile: null }; }, // init
             step: function (state, value, pctile) {
+                state.pctile = pctile;
                 state.vals.push(value);
+                return state;
             },
             finalize: function (state) {
                 return percentile(state.vals, state.pctile);
             }
         }
     );
-    var result = db.exec("SELECT percentile(col, 20) FROM test;");
-    assert.equal(result[0].values[0][0], 1, "Aggregate function with two args");
+    result = db.exec("SELECT percentile(col, 80) FROM test;");
+    assertFloat(result[0].values[0][0], 2.6, "Aggregate function with two args");
 
     db.create_aggregate(
         "json_agg", {
-            step: function(state, val) { state.push(val); },
+            step: function(state, val) { state = (state || []); state.push(val); return state; },
             finalize: function(state) { return JSON.stringify(state); }
         }
     );
 
     db.exec("CREATE TABLE test2 (col, col2);");
     db.exec("INSERT INTO test2 values ('four score', 12), ('and seven', 7), ('years ago', 1);");
-    var result = db.exec("SELECT json_agg(col) FROM test2;");
-    console.log("output: ", result[0].values);
+    result = db.exec("SELECT json_agg(col) FROM test2;");
     assert.deepEqual(JSON.parse(result[0].values[0]), ["four score", "and seven", "years ago"], "Aggregate function that returns JSON");
+
+    result = db.exec("SELECT json_agg(col), json_agg(col2) FROM test2;");
+    assert.deepEqual(result[0].values[0].map(JSON.parse), [["four score", "and seven", "years ago"], [12, 7, 1]], "Multiple aggregations at once");
 }
 
 // helper function to calculate a percentile from an array. Will modify the

--- a/test/test_aggregate_functions.js
+++ b/test/test_aggregate_functions.js
@@ -2,7 +2,7 @@ exports.test = function (SQL, assert) {
     var db = new SQL.Database();
 
     db.create_aggregate(
-        "js_sum",
+        "sum",
         function () { return { sum: 0 }; },
         function (state, value) { state.sum += value; },
         function (state) { return state.sum; }
@@ -10,8 +10,46 @@ exports.test = function (SQL, assert) {
 
     db.exec("CREATE TABLE test (col);");
     db.exec("INSERT INTO test VALUES (1), (2), (3);");
-    var result = db.exec("SELECT js_sum(col) FROM test;");
+    var result = db.exec("SELECT sum(col) FROM test;");
     assert.equal(result[0].values[0][0], 6, "Simple aggregate function.");
 
-    // TODO: Add test cases..
+    db.create_aggregate(
+        "percentile",
+        function () { return { vals: [], pctile: null }; }, // init
+        function (state, value, pctile) {
+            state.vals.push(value);
+        },
+        function (state) {
+            return percentile(state.vals, state.pctile);
+        }
+    );
+    var result = db.exec("SELECT percentile(col, 20) FROM test;");
+    assert.equal(result[0].values[0][0], 1, "Aggregate function with two args");
+
+    db.create_aggregate(
+        "json_agg",
+        function() { return { vals: [] }; },
+        function(state, val) { state.vals.push(val); },
+        function(state) { return JSON.stringify(state.vals); }
+    );
+
+    db.exec("CREATE TABLE test2 (col, col2);");
+    db.exec("INSERT INTO test2 values ('four score', 12), ('and seven', 7), ('years ago', 1);");
+    var result = db.exec("SELECT json_agg(col) FROM test2;");
+    assert.deepEqual(JSON.parse(result[0].values[0]), ["four score", "and seven", "years ago"], "Aggregate function that returns JSON");
 }
+
+// helper function to calculate a percentile from an array. Will modify the
+// array in-place.
+function percentile(arr, p) {
+    arr.sort();
+    const pos = (arr.length - 1) * (p / 100);
+    const base = Math.floor(pos);
+    const rest = pos - base;
+    if (arr[base + 1] !== undefined) {
+        return arr[base] + rest * (arr[base + 1] - arr[base]);
+    } else {
+        return arr[base];
+    }
+};
+

--- a/test/test_aggregate_functions.js
+++ b/test/test_aggregate_functions.js
@@ -30,15 +30,15 @@ exports.test = function (SQL, assert) {
 
     db.create_aggregate(
         "json_agg", {
-            init: function() { return { vals: [] }; },
-            step: function(state, val) { state.vals.push(val); },
-            finalize: function(state) { return JSON.stringify(state.vals); }
+            step: function(state, val) { state.push(val); },
+            finalize: function(state) { return JSON.stringify(state); }
         }
     );
 
     db.exec("CREATE TABLE test2 (col, col2);");
     db.exec("INSERT INTO test2 values ('four score', 12), ('and seven', 7), ('years ago', 1);");
     var result = db.exec("SELECT json_agg(col) FROM test2;");
+    console.log("output: ", result[0].values);
     assert.deepEqual(JSON.parse(result[0].values[0]), ["four score", "and seven", "years ago"], "Aggregate function that returns JSON");
 }
 

--- a/test/test_aggregate_redefinition.js
+++ b/test/test_aggregate_redefinition.js
@@ -5,7 +5,7 @@ exports.test = function(sql, assert) {
     let lastStep = i == 1000;
     let db = new sql.Database();
     try {
-      db.create_aggregate("TestFunction"+i, 0, {step: (state, value) => i})
+      db.create_aggregate("TestFunction"+i, {step: (state, value) => i})
     } catch(e) {
       assert.ok(
         false,
@@ -37,7 +37,7 @@ exports.test = function(sql, assert) {
     {
       let lastStep = i == 1000;
       try {
-        db.create_aggregate("TestFunction", 0, {step: (state, value) => i})
+        db.create_aggregate("TestFunction", {step: (state, value) => i})
       } catch(e) {
         assert.ok(
           false,

--- a/test/test_aggregate_redefinition.js
+++ b/test/test_aggregate_redefinition.js
@@ -1,0 +1,80 @@
+exports.test = function(sql, assert) {
+  // Test 1: Create a database, Register single function, close database, repeat 1000 times
+  for (var i = 1; i <= 1000; i++) 
+  {
+    let lastStep = i == 1000;
+    let db = new sql.Database();
+    try {
+      db.create_aggregate("TestFunction"+i, 0, {step: (state, value) => i})
+    } catch(e) {
+      assert.ok(
+        false,
+        "Test 1: Recreate database "+i+"th times and register aggregate"
+        +" function failed with exception:"+e
+      );
+      db.close();
+      break;
+    }
+    var result = db.exec("SELECT TestFunction"+i+"(1)");
+    var result_str = result[0]["values"][0][0];
+    if(result_str != i || lastStep)
+    {
+      assert.equal(
+        result_str,
+        i,
+        "Test 1: Recreate database "+i+"th times and register aggregate function"
+      );
+      db.close();
+      break;
+    }
+    db.close();
+  }
+
+  // Test 2: Create a database, Register same function  1000 times, close database
+  {
+    let db = new sql.Database();
+    for (var i = 1; i <= 1000; i++) 
+    {
+      let lastStep = i == 1000;
+      try {
+        db.create_aggregate("TestFunction", 0, {step: (state, value) => i})
+      } catch(e) {
+        assert.ok(
+          false,
+          "Test 2: Reregister aggregate function "+i+"th times failed with"
+          +" exception:"+e
+        );
+        break;
+      }
+      var result = db.exec("SELECT TestFunction(1)");
+      var result_str = result[0]["values"][0][0];
+      if(result_str != i || lastStep)
+      {
+        assert.equal(
+          result_str,
+          i,
+          "Test 2: Reregister function "+i+"th times"
+        );
+        break;
+      }
+    }
+    db.close();
+  }
+};
+
+
+if (module == require.main) {
+	const target_file = process.argv[2];
+  const sql_loader = require('./load_sql_lib');
+  sql_loader(target_file).then((sql)=>{
+    require('test').run({
+      'test creating multiple functions': function(assert){
+        exports.test(sql, assert);
+      }
+    });
+  })
+  .catch((e)=>{
+    console.error(e);
+    assert.fail(e);
+  });
+}


### PR DESCRIPTION
This PR builds on #407, updating it to current HEAD, adding more tests, and documenting it.

This PR closes #204, and is composed mostly of the work that @AnyhowStep did so long ago in that thread.

#407 notes that [aggregate window functions](https://www.sqlite.org/windowfunctions.html#udfwinfunc) do not work, but I think that's a different issue that should be tackled in another PR.

The full list of changes follows:
- Update README.md to document `create_aggregate`
- extract `parseFunctionArguments` into a function that can be used by both `create_aggregate` and `create_function`
  - Please verify that nothing substantial has changed here - I'm worried I missed some small divergence between #407 and current HEAD and this function should only be an extraction, not changing any behavior
- extract `setFunctionResults` into a function
  - same caveats apply
- export the `sqlite3_aggregate_context` function
- Add the `create_aggregate` function
  - The signature: `create_aggregate(function_name, initial_value, { step: (state, ...value) =>, finalize: (state) =>})`
  - `create_aggregate` calls `sqlite3_aggregate_context` to allocate 1 byte of memory per instance of the aggregate function, which it uses as a key for its state array. [`sqlite3_aggregate_context` documentation](https://www.sqlite.org/c3ref/aggregate_context.html)
- Add tests
