### PR TITLE
Add support for es module and browser-only environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,9 @@ EMFLAGS_ESMODULE= \
 	-s MODULARIZE=1 \
 	-s EXPORT_NAME=loadWASM \
 
+EMFLAGS_WEB= \
+	-s ENVIRONMENT=web
+
 EMFLAGS_DEBUG = \
 	-s ASSERTIONS=1 \
 	-O1
@@ -93,7 +96,7 @@ dist/sql-wasm-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FI
 	rm out/tmp-raw.js
 
 .PHONY: optimized
-optimized: dist/sql-asm.js dist/sql-wasm.js dist/sql-asm-memory-growth.js dist/sql-wasm-module.js
+optimized: dist/sql-asm.js dist/sql-wasm.js dist/sql-asm-memory-growth.js dist/sql-wasm-module.js dist/sql-wasm-module-web.js
 
 dist/sql-asm.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
 	$(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_ASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
@@ -109,6 +112,9 @@ dist/sql-wasm.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $
 
 dist/sql-wasm-module.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
 	$(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_ESMODULE) $(EMFLAGS_WASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
+
+dist/sql-wasm-module-web.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
+	$(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_ESMODULE) $(EMFLAGS_WEB) $(EMFLAGS_WASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
 
 dist/sql-asm-memory-growth.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
 	$(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_ASM_MEMORY_GROWTH) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,11 @@ EMFLAGS_OPTIMIZED= \
 	-flto \
 	--closure 1
 
+EMFLAGS_ESMODULE= \
+	-s EXPORT_ES6=1 \
+	-s MODULARIZE=1 \
+	-s EXPORT_NAME=loadWASM \
+
 EMFLAGS_DEBUG = \
 	-s ASSERTIONS=1 \
 	-O1
@@ -88,7 +93,7 @@ dist/sql-wasm-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FI
 	rm out/tmp-raw.js
 
 .PHONY: optimized
-optimized: dist/sql-asm.js dist/sql-wasm.js dist/sql-asm-memory-growth.js
+optimized: dist/sql-asm.js dist/sql-wasm.js dist/sql-asm-memory-growth.js dist/sql-wasm-module.js
 
 dist/sql-asm.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
 	$(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_ASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
@@ -101,6 +106,9 @@ dist/sql-wasm.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $
 	mv $@ out/tmp-raw.js
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
 	rm out/tmp-raw.js
+
+dist/sql-wasm-module.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
+	$(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_ESMODULE) $(EMFLAGS_WASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
 
 dist/sql-asm-memory-growth.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
 	$(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_ASM_MEMORY_GROWTH) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@

--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ There are a few examples [available here](https://sql-js.github.io/sql.js/index.
 ## Examples
 The test files provide up to date example of the use of the api.
 ### Inside the browser
+
+#### Using ES Modules
+This package supports exports an es module that works with bundlers like webpack:
+```js
+const SQL = await import("sql.js");
+
+const db = new SQL.Database();
+console.log(db.exec("select 1"));
+```
+
+You may need to enable features in your bundler, e.g. `asyncWebassembly` and `topLevelAwait` in [Webpack 5](https://webpack.js.org/configuration/experiments/).
+
 #### Example **HTML** file:
 ```html
 <meta charset="utf8" />

--- a/module-web.js
+++ b/module-web.js
@@ -1,0 +1,5 @@
+import * as wasm from "./dist/sql-wasm-module-web"
+
+const def = await wasm.default();
+
+export const Database = def.Database;

--- a/module.js
+++ b/module.js
@@ -1,0 +1,5 @@
+import * as wasm from "./dist/sql-wasm-module"
+
+const def = await wasm.default();
+
+export const Database = def.Database;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 	],
 	"license": "MIT",
 	"main": "./dist/sql-wasm.js",
+	"module": "./module.js",
 	"scripts": {
 		"build": "make",
 		"rebuild": "npm run clean && npm run build",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
 	"license": "MIT",
 	"main": "./dist/sql-wasm.js",
 	"module": "./module.js",
+	"browser": {
+		"./module.js": "./module-web.js"
+	},
 	"scripts": {
 		"build": "make",
 		"rebuild": "npm run clean && npm run build",


### PR DESCRIPTION
This PR addresses #284.

I've tested this change using the current `create-react-app` along with this webpack config:
```js
configure: (webpackConfig) => {
  webpackConfig.resolve.extensions.push(".wasm");
  webpackConfig.experiments = {
    asyncWebAssembly: true,
    topLevelAwait: true,
  };
  webpackConfig.module.rules.forEach((rule) => {
    (rule.oneOf || []).forEach((oneOf) => {
      if (oneOf.type === "asset/resource") {
        oneOf.exclude.push(/\.wasm$/);
      }
    });
  });
  return webpackConfig;
},
```