### PR TITLE
Add a comment to emphasize the async context when using `fetch` to `load a database`

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ const sqlPromise = initSqlJs({
   locateFile: file => `https://path/to/your/dist/folder/dist/${file}`
 });
 const dataPromise = fetch("/path/to/database.sqlite").then(res => res.arrayBuffer());
-const [SQL, buf] = await Promise.all([sqlPromise, dataPromise])
+const [SQL, buf] = await Promise.all([sqlPromise, dataPromise]); // needed to be run in a async context
 const db = new SQL.Database(new Uint8Array(buf));
 ```
 


### PR DESCRIPTION
#557 
This note emphasizes the example of using `fetch` to `load a database in the browser` needs to be run in an async context.