### PR TITLE
Register Extension Functions After Export

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1088,6 +1088,7 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
         var binaryDb = FS.readFile(this.filename, { encoding: "binary" });
         this.handleError(sqlite3_open(this.filename, apiTemp));
         this.db = getValue(apiTemp, "i32");
+        registerExtensionFunctions(this.db);
         return binaryDb;
     };
 

--- a/test/test_extension_functions.js
+++ b/test/test_extension_functions.js
@@ -69,6 +69,9 @@ exports.test = function(sql, assert) {
   var res = db.exec("SELECT reverse(str_data) FROM test;");
   assert.equal(res[0]['values'][0][0], "!dlroW olleH", "reverse() function works");
 
+  db.export()
+  var res = db.exec("SELECT floor(4.1)");
+  assert.equal(res[0]['values'][0][0], 4, "extension function works after export()");
 };
 
 if (module == require.main) {


### PR DESCRIPTION
Because the export method closes and reopens the database, it must follow the same initialization steps that occur during the first open. One step that was missing was registering extension functions. This commit does the following:
- Added call to registerExtensionFunctions() after the database is reloaded during the exportDatabase() call.
- Added test for this scenario.