### PR TITLE
feat: add browser-only WASM build variant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,11 @@ EMFLAGS_WASM = \
 	-s WASM=1 \
 	-s ALLOW_MEMORY_GROWTH=1
 
+EMFLAGS_WASM_BROWSER = \
+	-s WASM=1 \
+	-s ALLOW_MEMORY_GROWTH=1 \
+	-s ENVIRONMENT=web,worker
+
 EMFLAGS_OPTIMIZED= \
 	-Oz \
 	-flto \
@@ -73,7 +78,7 @@ EXPORTED_METHODS_JSON_FILES = src/exported_functions.json src/exported_runtime_m
 all: optimized debug worker
 
 .PHONY: debug
-debug: dist/sql-asm-debug.js dist/sql-wasm-debug.js
+debug: dist/sql-asm-debug.js dist/sql-wasm-debug.js dist/sql-wasm-browser-debug.js
 
 dist/sql-asm-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
 	$(EMCC) $(EMFLAGS) $(EMFLAGS_DEBUG) $(EMFLAGS_ASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
@@ -87,8 +92,14 @@ dist/sql-wasm-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FI
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
 	rm out/tmp-raw.js
 
+dist/sql-wasm-browser-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
+	$(EMCC) $(EMFLAGS) $(EMFLAGS_DEBUG) $(EMFLAGS_WASM_BROWSER) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
+	mv $@ out/tmp-raw.js
+	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
+	rm out/tmp-raw.js
+
 .PHONY: optimized
-optimized: dist/sql-asm.js dist/sql-wasm.js dist/sql-asm-memory-growth.js
+optimized: dist/sql-asm.js dist/sql-wasm.js dist/sql-wasm-browser.js dist/sql-asm-memory-growth.js
 
 dist/sql-asm.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
 	$(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_ASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
@@ -98,6 +109,12 @@ dist/sql-asm.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(
 
 dist/sql-wasm.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
 	$(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_WASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
+	mv $@ out/tmp-raw.js
+	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
+	rm out/tmp-raw.js
+
+dist/sql-wasm-browser.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
+	$(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_WASM_BROWSER) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
 	mv $@ out/tmp-raw.js
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
 	rm out/tmp-raw.js

--- a/package.json
+++ b/package.json
@@ -18,6 +18,13 @@
 	],
 	"license": "MIT",
 	"main": "./dist/sql-wasm.js",
+	"exports": {
+		".": {
+			"browser": "./dist/sql-wasm-browser.js",
+			"default": "./dist/sql-wasm.js"
+		},
+		"./dist/*": "./dist/*"
+	},
 	"scripts": {
 		"build": "make",
 		"rebuild": "npm run clean && npm run build",


### PR DESCRIPTION
## Summary

When bundling sql.js for browser environments, tools like Vite, Webpack, and esbuild emit warnings about `require("node:fs")` and `require("node:crypto")` being externalized for browser compatibility. These `require()` calls exist in the emcc-generated code because the default `ENVIRONMENT` includes `node`.

This PR adds a new `sql-wasm-browser.js` build variant that eliminates these warnings:

- **New `EMFLAGS_WASM_BROWSER`** in Makefile: same as `EMFLAGS_WASM` but with `-s ENVIRONMENT=web,worker`, which tells Emscripten to strip all Node.js code paths at compile time
- **New build targets**: `dist/sql-wasm-browser.js` (optimized) and `dist/sql-wasm-browser-debug.js` (debug)
- **Conditional exports** in `package.json`: bundlers targeting browsers automatically resolve to the clean `sql-wasm-browser.js` via the `browser` condition, while Node.js and other environments continue using the original `sql-wasm.js`

### Before (bundler output)
```
[plugin rolldown:vite-resolve] Module "fs" has been externalized for browser compatibility...
[plugin rolldown:vite-resolve] Module "crypto" has been externalized for browser compatibility...
[plugin rolldown:vite-resolve] Module "path" has been externalized for browser compatibility...
```

### After
No sql.js related warnings.

### Build comparison
| File | `require()` calls | Size |
|---|---|---|
| `sql-wasm.js` (unchanged) | `require("node:fs")`, `require("node:crypto")` | 45.7 KB |
| `sql-wasm-browser.js` (new) | None | 44.3 KB |
| `.wasm` binary | Both identical | 658 KB |

No breaking changes — the original `sql-wasm.js` is fully preserved as the `default` export.

Closes #620

## Test plan

- [x] Build `sql-wasm-browser.js` with `make dist/sql-wasm-browser.js` — succeeds
- [x] Verify `sql-wasm-browser.js` contains zero `require()` calls
- [x] Verify `sql-wasm.js` still contains Node.js support code
- [x] Test in a real Vite/WXT project — bundler warnings eliminated

🤖 Generated with [Claude Code](https://claude.com/claude-code)