### PR TITLE
fix: restore WASM stack in Database.exec to prevent stack leak (#630)

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -946,6 +946,7 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
         if (!this.db) {
             throw "Database closed";
         }
+        var stack = stackSave();
         var stmt = null;
         var originalSqlPtr = null;
         var currentSqlPtr = null;
@@ -993,6 +994,7 @@ Module["onRuntimeInitialized"] = function onRuntimeInitialized() {
             throw errCaught;
         } finally {
             if (originalSqlPtr) _free(originalSqlPtr);
+            stackRestore(stack);
         }
     };
 

--- a/test/test_issue630.js
+++ b/test/test_issue630.js
@@ -1,0 +1,48 @@
+
+exports.test = function(sql, assert) {
+    "use strict";
+    var db = new sql.Database();
+    db.run("CREATE TABLE t (x); INSERT INTO t VALUES (1);");
+
+    var before = sql.stackSave();
+    for (var i = 0; i < 1000; i++) {
+        db.exec("SELECT x FROM t");
+    }
+    assert.strictEqual(
+        before - sql.stackSave(),
+        0,
+        "exec() should not leak stack memory after repeated successful calls"
+    );
+
+    for (var j = 0; j < 100; j++) {
+        assert.throws(
+            function () { db.exec("SELECT * FROM does_not_exist"); },
+            "no such table: does_not_exist",
+            "exec() should throw for a failing query"
+        );
+    }
+    assert.strictEqual(
+        before - sql.stackSave(),
+        0,
+        "exec() should not leak stack memory after repeated failing calls"
+    );
+
+    // Close the database and all associated statements
+    db.close();
+};
+
+if (module == require.main) {
+  const target_file = process.argv[2];
+  const sql_loader = require('./load_sql_lib');
+  sql_loader(target_file).then((sql)=>{
+    require('test').run({
+      'test issue630': function(assert){
+        exports.test(sql, assert);
+      }
+    });
+  })
+  .catch((e)=>{
+    console.error(e);
+    assert.fail(e);
+  });
+}


### PR DESCRIPTION
Fixes #630

## Problem

`Database.prototype.exec` calls `stackAlloc(4)` for `pzTail` but never pairs the allocation with `stackSave()`/`stackRestore()`. Every `exec()` call permanently consumes 16 bytes of the WASM stack, whether it succeeds or throws.

This is a regression from #606 (`ee67aeb`): that PR moved the SQL string from the stack to the heap (`stringToNewUTF8`) and correctly removed the surrounding `stackSave()`/`stackRestore()`, but left `pzTail = stackAlloc(4)` in place without cleanup. `StatementIterator.next()` does the same `pzTail` allocation but properly restores the stack in a `finally` block.

With the 5MB stack this exhausts after ~327k `exec()` calls (~16 bytes each), after which the module is corrupted (export/run/new Database all fail with unrelated errors) and the process can only be recovered by restarting. Long-lived processes using `exec()` as their normal query path hit this deterministically.

## Fix

Restore the stack save/restore around `exec()`:

```js
var stack = stackSave();
// ...
} finally {
    if (originalSqlPtr) _free(originalSqlPtr);
    stackRestore(stack);
}
```

This keeps #606's desirable heap-allocation of the SQL string while freeing only the small per-call `pzTail` temporary.

## Test

Added `test/test_issue630.js` which asserts `SQL.stackSave()` is unchanged after 1000 successful `exec()` calls and 100 failing ones. Verified the test fails without the fix (leak of 16000 after 1000 calls) and passes with it.

All 24 tests pass on wasm, wasm-debug, asm, and lint is clean.